### PR TITLE
Dont use h tags in the heading README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-<h1 align="center">
+<p align="center">
   <a href="https://www.rig.dev">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://github.com/rigdev/rig/assets/3807831/95fa4658-a3be-4b8b-beba-febaef26def1">
       <img alt="rig" src="https://github.com/rigdev/rig/assets/3807831/b40ae289-0395-4cc3-9712-ccb9e9e2db3a" width="40%">
     </picture>
   </a>
-</h1>
+</p>
 
-<h4 align="center"><a href="https://docs.rig.dev/">Documentation</a> | <a href="https://rig.dev/">Website</a></h4>
+<p align="center"><b><a href="https://docs.rig.dev/">Documentation</a> | <a href="https://rig.dev/">Website</a></b></p>
 
 <p align="center">
   The open-source cloud development platform for Kubernetes


### PR DESCRIPTION
Github generates copy link to heading buttons for all <hX> elements. We dont want those in the heading.