### PR TITLE
:bug: fix goreleaser build of rig cli

### DIFF
--- a/build/package/goreleaser/goreleaser.yml
+++ b/build/package/goreleaser/goreleaser.yml
@@ -1,7 +1,8 @@
 builds:
   - id: rig
     binary: rig
-    main: ./cmd/rig
+    dir: ./cmd/rig
+    main: ./
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
Because the rig cli is it's own go module, we need to change directory
before we build the binary.
