### PR TITLE
🐛 Fix clash between k8s svc discovery and rig env var

### DIFF
--- a/deploy/charts/rig/Chart.yaml
+++ b/deploy/charts/rig/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/rig/templates/ingress.yaml
+++ b/deploy/charts/rig/templates/ingress.yaml
@@ -28,7 +28,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ include "rig.fullname" $ }}
+                name: {{ include "rig.fullname" $ }}-svc
                 port:
                   number: {{ $.Values.service.port }}
     {{- end }}

--- a/deploy/charts/rig/templates/service.yaml
+++ b/deploy/charts/rig/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "rig.fullname" . }}
+  name: {{ include "rig.fullname" . }}-svc
   labels: {{ include "rig.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}


### PR DESCRIPTION
Kubernetes service discovery creates an environment variable called
`<service-name>-PORT` for each service in the namespace where a pod
runs. The main service in the chart used the fullname helper as name.
When using rig as release name this resulted in the service being called
`rig`. This then means that each pod in the namespace would get an
environment variable called `RIG_PORT`. This clashes with the
environment override of `port` in the rig config.

This fix changes the service name by adding `-svc` as suffix. The
service discovery variable will hence be `RIG_SVC_PORT` and no longer
cause a clash.
