### PR TITLE
CMD Prompt for login & project use

### DIFF
--- a/cmd/rig/cmd/auth/get.go
+++ b/cmd/rig/cmd/auth/get.go
@@ -9,12 +9,12 @@ import (
 	"github.com/rigdev/rig-go-api/api/v1/authentication"
 	"github.com/rigdev/rig-go-sdk"
 	"github.com/rigdev/rig/cmd/common"
-	"github.com/rigdev/rig/cmd/rig/cmd/base"
+	"github.com/rigdev/rig/cmd/rig/cmd/cmd_config"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
 
-func AuthGet(ctx context.Context, cmd *cobra.Command, args []string, nc rig.Client, cfg *base.Config, logger *zap.Logger) error {
+func AuthGet(ctx context.Context, cmd *cobra.Command, args []string, nc rig.Client, cfg *cmd_config.Config, logger *zap.Logger) error {
 	res, err := nc.Authentication().Get(ctx, &connect.Request[authentication.GetRequest]{
 		Msg: &authentication.GetRequest{},
 	})

--- a/cmd/rig/cmd/auth/get_auth_config.go
+++ b/cmd/rig/cmd/auth/get_auth_config.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rigdev/rig-go-api/api/v1/project"
 	"github.com/rigdev/rig-go-sdk"
 	"github.com/rigdev/rig/cmd/common"
-	"github.com/rigdev/rig/cmd/rig/cmd/base"
+	"github.com/rigdev/rig/cmd/rig/cmd/cmd_config"
 	"github.com/rigdev/rig/pkg/auth"
 	"github.com/rigdev/rig/pkg/errors"
 	"github.com/rigdev/rig/pkg/uuid"
@@ -17,7 +17,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func AuthGetAuthConfig(ctx context.Context, cmd *cobra.Command, args []string, nc rig.Client, cfg *base.Config, logger *zap.Logger) error {
+func AuthGetAuthConfig(ctx context.Context, cmd *cobra.Command, args []string, nc rig.Client, cfg *cmd_config.Config, logger *zap.Logger) error {
 	var projectID uuid.UUID
 	var err error
 	if len(args) != 1 {

--- a/cmd/rig/cmd/auth/login.go
+++ b/cmd/rig/cmd/auth/login.go
@@ -9,14 +9,14 @@ import (
 	"github.com/rigdev/rig-go-api/model"
 	"github.com/rigdev/rig-go-sdk"
 	"github.com/rigdev/rig/cmd/common"
-	"github.com/rigdev/rig/cmd/rig/cmd/base"
+	"github.com/rigdev/rig/cmd/rig/cmd/cmd_config"
 	"github.com/rigdev/rig/pkg/auth"
 	"github.com/rigdev/rig/pkg/errors"
 	"github.com/rigdev/rig/pkg/uuid"
 	"github.com/spf13/cobra"
 )
 
-func AuthLogin(ctx context.Context, cmd *cobra.Command, client rig.Client, cfg *base.Config) error {
+func AuthLogin(ctx context.Context, cmd *cobra.Command, client rig.Client, cfg *cmd_config.Config) error {
 	res, err := loginWithRetry(ctx, client, authUserIdentifier, authPassword, auth.RigProjectID.String())
 	if err != nil {
 		return err
@@ -27,9 +27,9 @@ func AuthLogin(ctx context.Context, cmd *cobra.Command, client rig.Client, cfg *
 		return err
 	}
 
-	cfg.Auth().UserID = uid
-	cfg.Auth().AccessToken = res.Msg.GetToken().GetAccessToken()
-	cfg.Auth().RefreshToken = res.Msg.GetToken().GetRefreshToken()
+	cfg.GetCurrentAuth().UserID = uid
+	cfg.GetCurrentAuth().AccessToken = res.Msg.GetToken().GetAccessToken()
+	cfg.GetCurrentAuth().RefreshToken = res.Msg.GetToken().GetRefreshToken()
 	if err := cfg.Save(); err != nil {
 		return err
 	}

--- a/cmd/rig/cmd/auth/setup.go
+++ b/cmd/rig/cmd/auth/setup.go
@@ -22,7 +22,11 @@ func Setup(parent *cobra.Command) {
 		Use:   "login",
 		Short: "Login with user identifier and password",
 		Args:  cobra.NoArgs,
-		RunE:  base.Register(AuthLogin),
+		Annotations: map[string]string{
+			base.OmitUser:    "",
+			base.OmitProject: "",
+		},
+		RunE: base.Register(AuthLogin),
 	}
 	login.Flags().StringVarP(&authUserIdentifier, "user", "u", "", "useridentifier [username | email | phone number]")
 	login.Flags().StringVarP(&authPassword, "password", "p", "", "password of the user")
@@ -33,6 +37,9 @@ func Setup(parent *cobra.Command) {
 		Short: "Get user information associated with the current user",
 		Args:  cobra.NoArgs,
 		RunE:  base.Register(AuthGet),
+		Annotations: map[string]string{
+			base.OmitProject: "",
+		},
 	}
 	get.Flags().BoolVar(&outputJSON, "json", false, "Output as JSON")
 	auth.AddCommand(get)
@@ -42,6 +49,9 @@ func Setup(parent *cobra.Command) {
 		Short: "Get the authorization config with allowed login methods and configurations",
 		Args:  cobra.MaximumNArgs(1),
 		RunE:  base.Register(AuthGetAuthConfig),
+		Annotations: map[string]string{
+			base.OmitProject: "",
+		},
 	}
 	getAuthConfig.Flags().StringVarP(&redirectAddr, "redirect-addr", "r", "", "redirect address for oauth2")
 	getAuthConfig.Flags().BoolVar(&outputJSON, "json", false, "Output as JSON")

--- a/cmd/rig/cmd/base/auth.go
+++ b/cmd/rig/cmd/base/auth.go
@@ -1,0 +1,161 @@
+package base
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/bufbuild/connect-go"
+	"github.com/rigdev/rig-go-api/api/v1/authentication"
+	"github.com/rigdev/rig-go-api/api/v1/project"
+	"github.com/rigdev/rig-go-api/model"
+	"github.com/rigdev/rig-go-sdk"
+	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/cmd/rig/cmd/cmd_config"
+	"github.com/rigdev/rig/pkg/auth"
+	"github.com/rigdev/rig/pkg/errors"
+	"github.com/rigdev/rig/pkg/uuid"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+var (
+	OmitUser    = "OMIT_USER"
+	OmitProject = "OMIT_PROJECT"
+)
+
+func CheckAuth(cmd *cobra.Command, rc rig.Client, cfg *cmd_config.Config, logger *zap.Logger) error {
+	if _, ok := cmd.Annotations[OmitUser]; ok {
+		return nil
+	} else if uuid.UUID(cfg.GetCurrentAuth().UserID).IsNil() {
+		login, err := common.PromptConfirm("You are not logged in. Would you like to login now?", true)
+		if err != nil {
+			return err
+		}
+		if !login {
+			return errors.UnauthenticatedErrorf("Login to continue")
+		}
+		err = Login(rc, cfg)
+		if err != nil {
+			return err
+		}
+	}
+
+	if _, ok := cmd.Annotations[OmitProject]; ok {
+		return nil
+	} else if uuid.UUID(cfg.GetCurrentContext().Project.ProjectID).IsNil() {
+		use, err := common.PromptConfirm("You have not selected a project. Would you like to select one now?", true)
+		if err != nil {
+			return err
+		}
+		if !use {
+			return errors.FailedPreconditionErrorf("Select a project to continue")
+		}
+		err = UseProject(rc, cfg)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func Login(rc rig.Client, cfg *cmd_config.Config) error {
+	u, err := common.PromptGetInput("Enter Username or Email", common.ValidateNonEmpty)
+	if err != nil {
+		return err
+	}
+
+	var id *model.UserIdentifier
+	if strings.Contains(u, "@") {
+		id = &model.UserIdentifier{
+			Identifier: &model.UserIdentifier_Email{
+				Email: u,
+			},
+		}
+	} else {
+		id = &model.UserIdentifier{
+			Identifier: &model.UserIdentifier_Username{
+				Username: u,
+			},
+		}
+	}
+
+	pw, err := common.GetPasswordPrompt("Enter Password")
+	if err != nil {
+		return err
+	}
+
+	res, err := rc.Authentication().Login(context.Background(), &connect.Request[authentication.LoginRequest]{
+		Msg: &authentication.LoginRequest{
+			Method: &authentication.LoginRequest_UserPassword{
+				UserPassword: &authentication.UserPassword{
+					Identifier: id,
+					Password:   pw,
+					ProjectId:  auth.RigProjectID.String(),
+				},
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	uid, err := uuid.Parse(res.Msg.GetUserId())
+	if err != nil {
+		return err
+	}
+
+	cfg.GetCurrentAuth().UserID = uid
+	cfg.GetCurrentAuth().AccessToken = res.Msg.GetToken().GetAccessToken()
+	cfg.GetCurrentAuth().RefreshToken = res.Msg.GetToken().GetRefreshToken()
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+
+	fmt.Println("Login successful!")
+	return nil
+}
+
+func UseProject(rc rig.Client, cfg *cmd_config.Config) error {
+	var projectID uuid.UUID
+	var err error
+	ctx := context.Background()
+	list_res, err := rc.Project().List(ctx, &connect.Request[project.ListRequest]{})
+	if err != nil {
+		return err
+	}
+
+	var ps []string
+	for _, p := range list_res.Msg.GetProjects() {
+		ps = append(ps, p.GetName())
+	}
+
+	i, _, err := common.PromptSelect("Project: ", ps, false)
+	if err != nil {
+		return err
+	}
+
+	projectID, err = uuid.Parse(list_res.Msg.GetProjects()[i].GetProjectId())
+	if err != nil {
+		return err
+	}
+
+	res, err := rc.Project().Use(ctx, &connect.Request[project.UseRequest]{
+		Msg: &project.UseRequest{
+			ProjectId: projectID.String(),
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	cfg.GetCurrentContext().Project.ProjectID = projectID
+	cfg.GetCurrentContext().Project.ProjectToken = res.Msg.GetProjectToken()
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+
+	fmt.Println("Changed project successfully!")
+
+	return nil
+}

--- a/cmd/rig/cmd/base/register.go
+++ b/cmd/rig/cmd/base/register.go
@@ -39,6 +39,7 @@ func Register(f interface{}) func(cmd *cobra.Command, args []string) error {
 			}),
 			fx.Provide(func() context.Context { return context.Background() }),
 			fx.Options(_options...),
+			fx.Invoke(CheckAuth),
 			fx.Invoke(f),
 			fx.NopLogger,
 		)

--- a/cmd/rig/cmd/base/register.go
+++ b/cmd/rig/cmd/base/register.go
@@ -32,10 +32,10 @@ func Register(f interface{}) func(cmd *cobra.Command, args []string) error {
 			fx.Provide(zap.NewDevelopment),
 			fx.Provide(getContext),
 			fx.Provide(func(c *cmd_config.Context) *cmd_config.Auth {
-				return c.Auth
+				return c.GetAuth()
 			}),
 			fx.Provide(func(c *cmd_config.Context) *cmd_config.Service {
-				return c.Service
+				return c.GetService()
 			}),
 			fx.Provide(func() context.Context { return context.Background() }),
 			fx.Options(_options...),
@@ -74,13 +74,15 @@ func getContext(cfg *cmd_config.Config, cmd *cobra.Command) (*cmd_config.Context
 		return nil, fmt.Errorf("no current context in config, run `rig config init`")
 	}
 
-	c.Service = cfg.GetCurrentService()
-	if c.Service == nil {
+	fmt.Println(c.GetService())
+	c.SetService(cfg.GetCurrentService())
+	fmt.Println(c.GetService())
+	if c.GetService() == nil {
 		return nil, fmt.Errorf("missing service config for context `%v`", cfg.CurrentContextName)
 	}
 
-	c.Auth = cfg.GetCurrentAuth()
-	if c.Auth == nil {
+	c.SetAuth(cfg.GetCurrentAuth())
+	if c.GetAuth() == nil {
 		return nil, fmt.Errorf("missing auth config for context `%v`", cfg.CurrentContextName)
 	}
 

--- a/cmd/rig/cmd/capsule/create.go
+++ b/cmd/rig/cmd/capsule/create.go
@@ -8,13 +8,13 @@ import (
 	"github.com/rigdev/rig-go-api/api/v1/capsule"
 	"github.com/rigdev/rig-go-sdk"
 	"github.com/rigdev/rig/cmd/common"
-	"github.com/rigdev/rig/cmd/rig/cmd/base"
+	"github.com/rigdev/rig/cmd/rig/cmd/cmd_config"
 	"github.com/rigdev/rig/pkg/errors"
 	"github.com/rigdev/rig/pkg/uuid"
 	"github.com/spf13/cobra"
 )
 
-func CapsuleCreate(ctx context.Context, cmd *cobra.Command, args []string, nc rig.Client, cfg *base.Config) error {
+func CapsuleCreate(ctx context.Context, cmd *cobra.Command, args []string, nc rig.Client, cfg *cmd_config.Config) error {
 	var err error
 	if name == "" {
 		name, err = common.PromptGetInput("Capsule name: ", common.ValidateSystemName)

--- a/cmd/rig/cmd/capsule/create_build.go
+++ b/cmd/rig/cmd/capsule/create_build.go
@@ -7,11 +7,11 @@ import (
 	"github.com/rigdev/rig-go-api/api/v1/capsule"
 	"github.com/rigdev/rig-go-sdk"
 	"github.com/rigdev/rig/cmd/common"
-	"github.com/rigdev/rig/cmd/rig/cmd/base"
+	"github.com/rigdev/rig/cmd/rig/cmd/cmd_config"
 	"github.com/spf13/cobra"
 )
 
-func CapsuleCreateBuild(ctx context.Context, cmd *cobra.Command, args []string, capsuleID CapsuleID, nc rig.Client, cfg *base.Config) error {
+func CapsuleCreateBuild(ctx context.Context, cmd *cobra.Command, args []string, capsuleID CapsuleID, nc rig.Client, cfg *cmd_config.Config) error {
 	var err error
 	if image == "" {
 		image, err = common.PromptGetInput("Enter image", common.ValidateImage)

--- a/cmd/rig/cmd/capsule/push.go
+++ b/cmd/rig/cmd/capsule/push.go
@@ -14,12 +14,12 @@ import (
 	"github.com/rigdev/rig-go-api/api/v1/capsule"
 	"github.com/rigdev/rig-go-sdk"
 	"github.com/rigdev/rig/cmd/common"
-	"github.com/rigdev/rig/cmd/rig/cmd/base"
+	"github.com/rigdev/rig/cmd/rig/cmd/cmd_config"
 	"github.com/rigdev/rig/pkg/uuid"
 	"github.com/spf13/cobra"
 )
 
-func CapsulePush(ctx context.Context, cmd *cobra.Command, args []string, capsuleID CapsuleID, nc rig.Client, cfg *base.Config) error {
+func CapsulePush(ctx context.Context, cmd *cobra.Command, args []string, capsuleID CapsuleID, nc rig.Client, cfg *cmd_config.Config) error {
 	var err error
 	if image == "" {
 		image, err = common.PromptGetInput("Enter Image", common.ValidateNonEmpty)

--- a/cmd/rig/cmd/cmd_config/config.go
+++ b/cmd/rig/cmd/cmd_config/config.go
@@ -1,4 +1,4 @@
-package base
+package cmd_config
 
 import (
 	"os"
@@ -17,16 +17,16 @@ type Auth struct {
 }
 
 type Context struct {
-	Name    string `yaml:"name"`
-	Service string `yaml:"service"`
-	User    string `yaml:"user"`
-	Project struct {
+	Name        string `yaml:"name"`
+	ServiceName string `yaml:"service"`
+	UserName    string `yaml:"user"`
+	Project     struct {
 		ProjectID    uuid.UUID `yaml:"project_id"`
 		ProjectToken string    `yaml:"project_token"`
 	} `yaml:"project"`
 
-	service *Service
-	auth    *Auth
+	Service *Service
+	Auth    *Auth
 }
 
 type Service struct {
@@ -46,14 +46,14 @@ type Config struct {
 
 	Users []*User `yaml:"users"`
 
-	CurrentContext string `yaml:"current_context"`
+	CurrentContextName string `yaml:"current_context"`
 
 	filePath string
 }
 
-func (cfg *Config) Context() *Context {
+func (cfg *Config) GetCurrentContext() *Context {
 	for _, c := range cfg.Contexts {
-		if c.Name == cfg.CurrentContext {
+		if c.Name == cfg.CurrentContextName {
 			return c
 		}
 	}
@@ -61,28 +61,28 @@ func (cfg *Config) Context() *Context {
 	return nil
 }
 
-func (cfg *Config) Auth() *Auth {
-	c := cfg.Context()
+func (cfg *Config) GetCurrentAuth() *Auth {
+	c := cfg.GetCurrentContext()
 	if c == nil {
 		return nil
 	}
 
 	for _, u := range cfg.Users {
-		if u.Name == c.User {
+		if u.Name == c.UserName {
 			return u.Auth
 		}
 	}
 	return nil
 }
 
-func (cfg *Config) Service() *Service {
-	c := cfg.Context()
+func (cfg *Config) GetCurrentService() *Service {
+	c := cfg.GetCurrentContext()
 	if c == nil {
 		return nil
 	}
 
 	for _, cl := range cfg.Services {
-		if cl.Name == c.Service {
+		if cl.Name == c.ServiceName {
 			return cl
 		}
 	}

--- a/cmd/rig/cmd/cmd_config/config.go
+++ b/cmd/rig/cmd/cmd_config/config.go
@@ -18,8 +18,8 @@ type Auth struct {
 
 type Context struct {
 	Name        string `yaml:"name"`
-	ServiceName string `yaml:"service"`
-	UserName    string `yaml:"user"`
+	ServiceName string `yaml:"service_name"`
+	UserName    string `yaml:"user_name"`
 	Project     struct {
 		ProjectID    uuid.UUID `yaml:"project_id"`
 		ProjectToken string    `yaml:"project_token"`

--- a/cmd/rig/cmd/cmd_config/config.go
+++ b/cmd/rig/cmd/cmd_config/config.go
@@ -18,15 +18,31 @@ type Auth struct {
 
 type Context struct {
 	Name        string `yaml:"name"`
-	ServiceName string `yaml:"service_name"`
-	UserName    string `yaml:"user_name"`
+	ServiceName string `yaml:"service"`
+	UserName    string `yaml:"user"`
 	Project     struct {
 		ProjectID    uuid.UUID `yaml:"project_id"`
 		ProjectToken string    `yaml:"project_token"`
 	} `yaml:"project"`
 
-	Service *Service
-	Auth    *Auth
+	service *Service
+	auth    *Auth
+}
+
+func (c *Context) GetService() *Service {
+	return c.service
+}
+
+func (c *Context) SetService(s *Service) {
+	c.service = s
+}
+
+func (c *Context) GetAuth() *Auth {
+	return c.auth
+}
+
+func (c *Context) SetAuth(a *Auth) {
+	c.auth = a
 }
 
 type Service struct {

--- a/cmd/rig/cmd/cmd_config/context.go
+++ b/cmd/rig/cmd/cmd_config/context.go
@@ -1,4 +1,4 @@
-package base
+package cmd_config
 
 import (
 	"fmt"
@@ -9,7 +9,7 @@ import (
 func UseContext(cfg *Config, name string) error {
 	for _, c := range cfg.Contexts {
 		if c.Name == name {
-			cfg.CurrentContext = c.Name
+			cfg.CurrentContextName = c.Name
 			return cfg.Save()
 		}
 	}
@@ -22,7 +22,7 @@ func SelectContext(cfg *Config) error {
 	var labels []string
 	for _, c := range cfg.Contexts {
 		names = append(names, c.Name)
-		if c.Name == cfg.CurrentContext {
+		if c.Name == cfg.CurrentContextName {
 			labels = append(labels, c.Name+"*")
 		} else {
 			labels = append(labels, c.Name)
@@ -34,7 +34,7 @@ func SelectContext(cfg *Config) error {
 		return err
 	}
 
-	cfg.CurrentContext = cfg.Contexts[n].Name
+	cfg.CurrentContextName = cfg.Contexts[n].Name
 	return cfg.Save()
 }
 
@@ -50,9 +50,9 @@ func CreateContext(cfg *Config) error {
 	}
 
 	cfg.Contexts = append(cfg.Contexts, &Context{
-		Name:    name,
-		Service: name,
-		User:    name,
+		Name:        name,
+		ServiceName: name,
+		UserName:    name,
 	})
 
 	cfg.Services = append(cfg.Services, &Service{
@@ -68,7 +68,7 @@ func CreateContext(cfg *Config) error {
 	if ok, err := common.PromptConfirm("Do you want activate this context now", true); err != nil {
 		return err
 	} else if ok {
-		cfg.CurrentContext = name
+		cfg.CurrentContextName = name
 	}
 
 	return cfg.Save()

--- a/cmd/rig/cmd/cmd_config/context.go
+++ b/cmd/rig/cmd/cmd_config/context.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/pkg/uuid"
 )
 
 func UseContext(cfg *Config, name string) error {
@@ -53,6 +54,13 @@ func CreateContext(cfg *Config) error {
 		Name:        name,
 		ServiceName: name,
 		UserName:    name,
+		Project: struct {
+			ProjectID    uuid.UUID `yaml:"project_id"`
+			ProjectToken string    `yaml:"project_token"`
+		}{
+			ProjectID:    uuid.Nil,
+			ProjectToken: "",
+		},
 	})
 
 	cfg.Services = append(cfg.Services, &Service{
@@ -62,7 +70,9 @@ func CreateContext(cfg *Config) error {
 
 	cfg.Users = append(cfg.Users, &User{
 		Name: name,
-		Auth: &Auth{},
+		Auth: &Auth{
+			UserID: uuid.Nil,
+		},
 	})
 
 	if ok, err := common.PromptConfirm("Do you want activate this context now", true); err != nil {

--- a/cmd/rig/cmd/config/init.go
+++ b/cmd/rig/cmd/config/init.go
@@ -5,17 +5,17 @@ import (
 	"fmt"
 
 	"github.com/rigdev/rig/cmd/common"
-	"github.com/rigdev/rig/cmd/rig/cmd/base"
+	"github.com/rigdev/rig/cmd/rig/cmd/cmd_config"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
 
-func ConfigInit(ctx context.Context, cmd *cobra.Command, cfg *base.Config, logger *zap.Logger) error {
+func ConfigInit(ctx context.Context, cmd *cobra.Command, cfg *cmd_config.Config, logger *zap.Logger) error {
 	if ok, err := common.PromptConfirm("Do you want to configure a new context", true); err != nil {
 		return err
 	} else if !ok {
 		return fmt.Errorf("aborted")
 	}
 
-	return base.CreateContext(cfg)
+	return cmd_config.CreateContext(cfg)
 }

--- a/cmd/rig/cmd/config/use_context.go
+++ b/cmd/rig/cmd/config/use_context.go
@@ -1,13 +1,13 @@
 package config
 
 import (
-	"github.com/rigdev/rig/cmd/rig/cmd/base"
+	"github.com/rigdev/rig/cmd/rig/cmd/cmd_config"
 )
 
-func ConfigUseContext(args []string, cfg *base.Config) error {
+func ConfigUseContext(args []string, cfg *cmd_config.Config) error {
 	if len(args) > 0 {
-		return base.UseContext(cfg, args[0])
+		return cmd_config.UseContext(cfg, args[0])
 	}
 
-	return base.SelectContext(cfg)
+	return cmd_config.SelectContext(cfg)
 }

--- a/cmd/rig/cmd/project/create.go
+++ b/cmd/rig/cmd/project/create.go
@@ -6,13 +6,13 @@ import (
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/project"
 	"github.com/rigdev/rig-go-sdk"
-	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/cmd/rig/cmd/cmd_config"
 	"github.com/rigdev/rig/pkg/uuid"
 	"github.com/spf13/cobra"
 )
 
-func ProjectCreate(ctx context.Context, cmd *cobra.Command, args []string, nc rig.Client, cfg *base.Config) error {
+func ProjectCreate(ctx context.Context, cmd *cobra.Command, args []string, nc rig.Client, cfg *cmd_config.Config) error {
 	if name == "" {
 		var err error
 		name, err = common.PromptGetInput("Project name:", common.ValidateNonEmpty)
@@ -51,8 +51,8 @@ func ProjectCreate(ctx context.Context, cmd *cobra.Command, args []string, nc ri
 			return err
 		}
 
-		cfg.Context().Project.ProjectID = uuid.UUID(p.GetProjectId())
-		cfg.Context().Project.ProjectToken = res.Msg.GetProjectToken()
+		cfg.GetCurrentContext().Project.ProjectID = uuid.UUID(p.GetProjectId())
+		cfg.GetCurrentContext().Project.ProjectToken = res.Msg.GetProjectToken()
 		if err := cfg.Save(); err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/project/list.go
+++ b/cmd/rig/cmd/project/list.go
@@ -9,12 +9,12 @@ import (
 	"github.com/rigdev/rig-go-api/api/v1/project"
 	"github.com/rigdev/rig-go-api/model"
 	"github.com/rigdev/rig-go-sdk"
-	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/cmd/rig/cmd/cmd_config"
 	"github.com/spf13/cobra"
 )
 
-func ProjectList(ctx context.Context, cmd *cobra.Command, args []string, nc rig.Client, cfg *base.Config) error {
+func ProjectList(ctx context.Context, cmd *cobra.Command, args []string, nc rig.Client, cfg *cmd_config.Config) error {
 	req := &project.ListRequest{
 		Pagination: &model.Pagination{
 			Offset: uint32(offset),

--- a/cmd/rig/cmd/project/setup.go
+++ b/cmd/rig/cmd/project/setup.go
@@ -66,6 +66,9 @@ func Setup(parent *cobra.Command) {
 		Use:  "create",
 		Args: cobra.NoArgs,
 		RunE: base.Register(ProjectCreate),
+		Annotations: map[string]string{
+			base.OmitProject: "",
+		},
 	}
 	createProject.Flags().StringVarP(&name, "name", "n", "", "Project name")
 	createProject.Flags().BoolVar(&useProject, "use", false, "Use the created project")
@@ -115,6 +118,9 @@ func Setup(parent *cobra.Command) {
 		Use:  "list",
 		Args: cobra.NoArgs,
 		RunE: base.Register(ProjectList),
+		Annotations: map[string]string{
+			base.OmitProject: "",
+		},
 	}
 	listProjects.Flags().IntVarP(&offset, "offset", "o", 0, "Offset")
 	listProjects.Flags().IntVarP(&limit, "limit", "l", 10, "Limit")

--- a/cmd/rig/cmd/project/use_project.go
+++ b/cmd/rig/cmd/project/use_project.go
@@ -6,15 +6,15 @@ import (
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/project"
 	"github.com/rigdev/rig-go-sdk"
-	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/cmd/rig/cmd/cmd_config"
 	"github.com/rigdev/rig/pkg/errors"
 	"github.com/rigdev/rig/pkg/uuid"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
 
-func ProjectUse(ctx context.Context, cmd *cobra.Command, args []string, nc rig.Client, cfg *base.Config, logger *zap.Logger) error {
+func ProjectUse(ctx context.Context, cmd *cobra.Command, args []string, nc rig.Client, cfg *cmd_config.Config, logger *zap.Logger) error {
 	var projectID uuid.UUID
 	var err error
 	if len(args) != 1 {
@@ -71,8 +71,8 @@ func ProjectUse(ctx context.Context, cmd *cobra.Command, args []string, nc rig.C
 		return err
 	}
 
-	cfg.Context().Project.ProjectID = projectID
-	cfg.Context().Project.ProjectToken = res.Msg.GetProjectToken()
+	cfg.GetCurrentContext().Project.ProjectID = projectID
+	cfg.GetCurrentContext().Project.ProjectToken = res.Msg.GetProjectToken()
 	if err := cfg.Save(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Added support for automatic prompting for login and selection 
of project. To omit the checks, add a base.OmitProject / 
base.OmitUser to the annotations of the cmd.

I have changed a bit in the contexts, so it is needed to remove 
the config.yaml file. Dunno where on linux or windows, but in 
mac the file is at:
Library/Application Support/rig/config.yaml
