### PR TITLE
Various cleanups in the CLI

### DIFF
--- a/cmd/common/prompt.go
+++ b/cmd/common/prompt.go
@@ -71,7 +71,7 @@ var InputDefaultOpt = func(def string) GetInputOption {
 	}
 }
 
-func PromptGetInput(label string, opts ...GetInputOption) (string, error) {
+func PromptInput(label string, opts ...GetInputOption) (string, error) {
 	input := textinput.New(label)
 	for _, opt := range opts {
 		input = opt(input)
@@ -84,7 +84,7 @@ func PromptGetInput(label string, opts ...GetInputOption) (string, error) {
 	return s, nil
 }
 
-func GetPasswordPrompt(label string) (string, error) {
+func PromptPassword(label string) (string, error) {
 	input := textinput.New(label)
 	input.Hidden = true
 	input.Validate = utils.ValidatePassword
@@ -109,7 +109,7 @@ func PromptSelect(label string, choices []string) (int, string, error) {
 }
 
 func PromptConfirm(label string, def bool) (bool, error) {
-	input := textinput.New(label + "?")
+	input := textinput.New(label)
 	input.Validate = ValidateBool
 	input.Template = confirmTemplateY
 	if !def {

--- a/cmd/common/useridentifier.go
+++ b/cmd/common/useridentifier.go
@@ -11,7 +11,7 @@ import (
 
 func PromptUserIndentifierUpdate() (*user.Update, error) {
 	var err error
-	identifier, err := PromptGetInput("Username, email or phone number:", ValidateAllOpt)
+	identifier, err := PromptInput("Username, email or phone number:", ValidateAllOpt)
 	if err != nil {
 		return nil, err
 	}
@@ -24,7 +24,7 @@ func PromptUserIndentifierUpdate() (*user.Update, error) {
 
 func PromptUserIndentifier() (*model.UserIdentifier, error) {
 	var err error
-	identifierStr, err := PromptGetInput("Username, email or phone number:", ValidateAllOpt)
+	identifierStr, err := PromptInput("Username, email or phone number:", ValidateAllOpt)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func GetUserAndPasswordUpdates(username, email, phoneNumber, password string) ([
 	}
 
 	if password == "" {
-		password, err = GetPasswordPrompt("Password:")
+		password, err = PromptPassword("Password:")
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/common/utils.go
+++ b/cmd/common/utils.go
@@ -106,7 +106,7 @@ func parseBool(s string) (bool, error) {
 func GetUser(ctx context.Context, identifier string, nc rig.Client) (*user.User, string, error) {
 	var err error
 	if identifier == "" {
-		identifier, err = PromptGetInput("User Identifier:", ValidateSystemNameOpt)
+		identifier, err = PromptInput("User Identifier:", ValidateSystemNameOpt)
 		if err != nil {
 			return nil, "", err
 		}
@@ -145,7 +145,7 @@ func GetUser(ctx context.Context, identifier string, nc rig.Client) (*user.User,
 func GetGroup(ctx context.Context, identifier string, nc rig.Client) (*group.Group, string, error) {
 	var err error
 	if identifier == "" {
-		identifier, err = PromptGetInput("Group Identifier:", ValidateSystemNameOpt)
+		identifier, err = PromptInput("Group Identifier:", ValidateSystemNameOpt)
 		if err != nil {
 			return nil, "", err
 		}
@@ -178,7 +178,7 @@ func GetGroup(ctx context.Context, identifier string, nc rig.Client) (*group.Gro
 func GetDatabase(ctx context.Context, identifier string, nc rig.Client) (*database.Database, string, error) {
 	var err error
 	if identifier == "" {
-		identifier, err = PromptGetInput("DB Identifier:", ValidateSystemNameOpt)
+		identifier, err = PromptInput("DB Identifier:", ValidateSystemNameOpt)
 		if err != nil {
 			return nil, "", err
 		}
@@ -212,7 +212,7 @@ func GetDatabase(ctx context.Context, identifier string, nc rig.Client) (*databa
 func GetStorageProvider(ctx context.Context, identifier string, nc rig.Client) (*storage.Provider, string, error) {
 	var err error
 	if identifier == "" {
-		identifier, err = PromptGetInput("Provider Identifier:", ValidateSystemNameOpt)
+		identifier, err = PromptInput("Provider Identifier:", ValidateSystemNameOpt)
 		if err != nil {
 			return nil, "", err
 		}

--- a/cmd/rig-admin/cmd/init.go
+++ b/cmd/rig-admin/cmd/init.go
@@ -74,11 +74,11 @@ func createUser(ctx context.Context, us user_service.Service) error {
 		return nil
 	}
 
-	email, err := common.PromptGetInput("Email of the new user:", common.ValidateEmailOpt)
+	email, err := common.PromptInput("Email of the new user:", common.ValidateEmailOpt)
 	if err != nil {
 		return err
 	}
-	password, err := common.GetPasswordPrompt("Password:")
+	password, err := common.PromptPassword("Password:")
 	if err != nil {
 		return err
 	}
@@ -122,7 +122,7 @@ func createProject(ctx context.Context, ps project_service.Service) error {
 	}
 
 	for {
-		projectName, err := common.PromptGetInput("Project name:", common.ValidateNonEmptyOpt)
+		projectName, err := common.PromptInput("Project name:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig-admin/cmd/users.go
+++ b/cmd/rig-admin/cmd/users.go
@@ -126,7 +126,7 @@ func UsersCreate(ctx context.Context, cmd *cobra.Command, us user_service.Servic
 	})
 
 	if userPassword == "" {
-		pw, err := common.GetPasswordPrompt("Password:")
+		pw, err := common.PromptPassword("Password:")
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/auth/get_auth_config.go
+++ b/cmd/rig/cmd/auth/get_auth_config.go
@@ -68,7 +68,7 @@ func AuthGetAuthConfig(ctx context.Context, cmd *cobra.Command, args []string, n
 	}
 
 	if redirectAddr == "" {
-		redirectAddr, err = common.PromptGetInput("Oauth Redirect Address", common.ValidateNonEmptyOpt)
+		redirectAddr, err = common.PromptInput("Oauth Redirect Address", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/auth/login.go
+++ b/cmd/rig/cmd/auth/login.go
@@ -55,7 +55,7 @@ func loginWithRetry(ctx context.Context, client rig.Client, identifierStr, passw
 		}
 
 		if shouldPromptPassword {
-			password, err = common.GetPasswordPrompt("Enter Password:")
+			password, err = common.PromptPassword("Enter Password:")
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/rig/cmd/base/auth.go
+++ b/cmd/rig/cmd/base/auth.go
@@ -85,7 +85,7 @@ func CheckAuth(cmd *cobra.Command, rc rig.Client, cfg *cmd_config.Config, logger
 }
 
 func createProject(ctx context.Context, cmd *cobra.Command, rc rig.Client, cfg *cmd_config.Config) error {
-	name, err := common.PromptGetInput("Project name:", common.ValidateNonEmptyOpt)
+	name, err := common.PromptInput("Project name:", common.ValidateNonEmptyOpt)
 	if err != nil {
 		return err
 	}
@@ -138,7 +138,7 @@ func createProject(ctx context.Context, cmd *cobra.Command, rc rig.Client, cfg *
 }
 
 func login(ctx context.Context, rc rig.Client, cfg *cmd_config.Config) error {
-	u, err := common.PromptGetInput("Enter Username or Email", common.ValidateNonEmptyOpt)
+	u, err := common.PromptInput("Enter Username or Email:", common.ValidateNonEmptyOpt)
 	if err != nil {
 		return err
 	}
@@ -158,7 +158,7 @@ func login(ctx context.Context, rc rig.Client, cfg *cmd_config.Config) error {
 		}
 	}
 
-	pw, err := common.GetPasswordPrompt("Enter Password")
+	pw, err := common.PromptPassword("Enter Password")
 	if err != nil {
 		return err
 	}

--- a/cmd/rig/cmd/capsule/configure_network.go
+++ b/cmd/rig/cmd/capsule/configure_network.go
@@ -19,7 +19,7 @@ import (
 func CapsuleConfigureNetwork(ctx context.Context, cmd *cobra.Command, args []string, capsuleID CapsuleID, nc rig.Client) error {
 	var err error
 	if networkFile == "" {
-		networkFile, err = common.PromptGetInput("Enter Network file path", common.ValidateNonEmptyOpt)
+		networkFile, err = common.PromptInput("Enter Network file path:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/capsule/create.go
+++ b/cmd/rig/cmd/capsule/create.go
@@ -17,7 +17,7 @@ import (
 func CapsuleCreate(ctx context.Context, cmd *cobra.Command, args []string, nc rig.Client, cfg *cmd_config.Config) error {
 	var err error
 	if name == "" {
-		name, err = common.PromptGetInput("Capsule name: ", common.ValidateSystemNameOpt)
+		name, err = common.PromptInput("Capsule name:", common.ValidateSystemNameOpt)
 		if err != nil {
 			return err
 		}
@@ -27,20 +27,20 @@ func CapsuleCreate(ctx context.Context, cmd *cobra.Command, args []string, nc ri
 	var image string
 	var replicas int
 	if interactive {
-		if ok, err := common.PromptConfirm("Do you want to add an initial image", true); err != nil {
+		if ok, err := common.PromptConfirm("Do you want to add an initial image?", true); err != nil {
 			return err
 		} else if ok {
-			if image, err = common.PromptGetInput("Image: ", common.ValidateImageOpt); err != nil {
+			if image, err = common.PromptInput("Image:", common.ValidateImageOpt); err != nil {
 				return err
 			}
 
-			if ok, err := common.PromptConfirm("Does the image listen to a port", true); err != nil {
+			if ok, err := common.PromptConfirm("Does the image listen to a port?", true); err != nil {
 				return err
 			} else if ok {
 				ifc := &capsule.Interface{
 					Name: "default",
 				}
-				portStr, err := common.PromptGetInput("Which port: ", common.ValidateIntOpt)
+				portStr, err := common.PromptInput("Which port:", common.ValidateIntOpt)
 				if err != nil {
 					return err
 				}
@@ -52,7 +52,7 @@ func CapsuleCreate(ctx context.Context, cmd *cobra.Command, args []string, nc ri
 
 				ifc.Port = uint32(port)
 
-				if ok, err := common.PromptConfirm("Do you want to make the port public available", false); err != nil {
+				if ok, err := common.PromptConfirm("Do you want to make the port public available?", false); err != nil {
 					return err
 				} else if ok {
 					ifc.Public = &capsule.PublicInterface{
@@ -67,7 +67,7 @@ func CapsuleCreate(ctx context.Context, cmd *cobra.Command, args []string, nc ri
 
 					switch i {
 					case 0:
-						portStr, err := common.PromptGetInput("What public port to use: ", common.ValidateIntOpt)
+						portStr, err := common.PromptInput("What public port to use:", common.ValidateIntOpt)
 						if err != nil {
 							return err
 						}
@@ -96,7 +96,7 @@ func CapsuleCreate(ctx context.Context, cmd *cobra.Command, args []string, nc ri
 				})
 			}
 		}
-		replicasStr, err := common.PromptGetInput("Replicas: ", common.ValidateIntOpt, common.InputDefaultOpt("1"))
+		replicasStr, err := common.PromptInput("Replicas:", common.ValidateIntOpt, common.InputDefaultOpt("1"))
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/capsule/create_build.go
+++ b/cmd/rig/cmd/capsule/create_build.go
@@ -14,7 +14,7 @@ import (
 func CapsuleCreateBuild(ctx context.Context, cmd *cobra.Command, args []string, capsuleID CapsuleID, nc rig.Client, cfg *cmd_config.Config) error {
 	var err error
 	if image == "" {
-		image, err = common.PromptGetInput("Enter image", common.ValidateImageOpt)
+		image, err = common.PromptInput("Enter image:", common.ValidateImageOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/capsule/deploy.go
+++ b/cmd/rig/cmd/capsule/deploy.go
@@ -13,7 +13,7 @@ import (
 func CapsuleDeploy(ctx context.Context, cmd *cobra.Command, args []string, capsuleID CapsuleID, nc rig.Client) error {
 	var err error
 	if buildID == "" {
-		buildID, err = common.PromptGetInput("Enter Build ID", common.ValidateNonEmptyOpt)
+		buildID, err = common.PromptInput("Enter Build ID:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/capsule/list.go
+++ b/cmd/rig/cmd/capsule/list.go
@@ -15,7 +15,6 @@ import (
 )
 
 func CapsuleList(ctx context.Context, cmd *cobra.Command, nc rig.Client, args []string) error {
-	fmt.Println("args: ", args)
 	resp, err := nc.Capsule().List(ctx, &connect.Request[capsule.ListRequest]{
 		Msg: &capsule.ListRequest{
 			Pagination: &model.Pagination{

--- a/cmd/rig/cmd/capsule/push.go
+++ b/cmd/rig/cmd/capsule/push.go
@@ -22,7 +22,7 @@ import (
 func CapsulePush(ctx context.Context, cmd *cobra.Command, args []string, capsuleID CapsuleID, nc rig.Client, cfg *cmd_config.Config) error {
 	var err error
 	if image == "" {
-		image, err = common.PromptGetInput("Enter Image", common.ValidateNonEmptyOpt)
+		image, err = common.PromptInput("Enter Image:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/capsule/scale.go
+++ b/cmd/rig/cmd/capsule/scale.go
@@ -15,7 +15,7 @@ import (
 func CapsuleScale(ctx context.Context, cmd *cobra.Command, args []string, capsuleID CapsuleID, nc rig.Client) error {
 	var r uint64
 	if replicas == -1 {
-		rString, err := common.PromptGetInput("Enter Replica Count", common.ValidateNonEmptyOpt)
+		rString, err := common.PromptInput("Enter Replica Count:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/capsule/setup.go
+++ b/cmd/rig/cmd/capsule/setup.go
@@ -213,7 +213,7 @@ func provideCapsuleID(ctx context.Context, nc rig.Client, args []string) (Capsul
 	var capsuleName string
 	var err error
 	if len(args) == 0 {
-		capsuleName, err = common.PromptGetInput("Enter Capsule name", common.ValidateNonEmptyOpt)
+		capsuleName, err = common.PromptInput("Enter Capsule name:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return "", err
 		}

--- a/cmd/rig/cmd/cmd_config/context.go
+++ b/cmd/rig/cmd/cmd_config/context.go
@@ -40,12 +40,12 @@ func SelectContext(cfg *Config) error {
 }
 
 func CreateContext(cfg *Config) error {
-	name, err := common.PromptGetInput("Name:", common.ValidateSystemNameOpt, common.InputDefaultOpt("local"))
+	name, err := common.PromptInput("Name:", common.ValidateSystemNameOpt, common.InputDefaultOpt("local"))
 	if err != nil {
 		return err
 	}
 
-	server, err := common.PromptGetInput("Server:", common.ValidateURLOpt, common.InputDefaultOpt("http://localhost:4747/"))
+	server, err := common.PromptInput("Server:", common.ValidateURLOpt, common.InputDefaultOpt("http://localhost:4747/"))
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func CreateContext(cfg *Config) error {
 		},
 	})
 
-	if ok, err := common.PromptConfirm("Do you want activate this context now", true); err != nil {
+	if ok, err := common.PromptConfirm("Do you want activate this context now?", true); err != nil {
 		return err
 	} else if ok {
 		cfg.CurrentContextName = name
@@ -85,7 +85,7 @@ func CreateContext(cfg *Config) error {
 }
 
 func ConfigInit(cfg *Config) error {
-	if ok, err := common.PromptConfirm("Do you want to configure a new context", true); err != nil {
+	if ok, err := common.PromptConfirm("Do you want to configure a new context?", true); err != nil {
 		return err
 	} else if !ok {
 		return nil

--- a/cmd/rig/cmd/config/init.go
+++ b/cmd/rig/cmd/config/init.go
@@ -11,7 +11,7 @@ import (
 )
 
 func ConfigInit(ctx context.Context, cmd *cobra.Command, cfg *cmd_config.Config, logger *zap.Logger) error {
-	if ok, err := common.PromptConfirm("Do you want to configure a new context", true); err != nil {
+	if ok, err := common.PromptConfirm("Do you want to configure a new context?", true); err != nil {
 		return err
 	} else if !ok {
 		return fmt.Errorf("aborted")

--- a/cmd/rig/cmd/config/setup.go
+++ b/cmd/rig/cmd/config/setup.go
@@ -15,6 +15,10 @@ func Setup(parent *cobra.Command) {
 		Short: "Initialize a new context",
 		Args:  cobra.NoArgs,
 		RunE:  base.Register(ConfigInit),
+		Annotations: map[string]string{
+			base.OmitProject: "",
+			base.OmitUser:    "",
+		},
 	}
 	config.AddCommand(init)
 
@@ -23,6 +27,10 @@ func Setup(parent *cobra.Command) {
 		Short: "Change the current context to use",
 		Args:  cobra.MaximumNArgs(1),
 		RunE:  base.Register(ConfigUseContext),
+		Annotations: map[string]string{
+			base.OmitProject: "",
+			base.OmitUser:    "",
+		},
 	}
 	config.AddCommand(useContext)
 

--- a/cmd/rig/cmd/database/connect.go
+++ b/cmd/rig/cmd/database/connect.go
@@ -21,14 +21,14 @@ func Connect(ctx context.Context, cmd *cobra.Command, args []string, nc rig.Clie
 	}
 
 	if clientID == "" {
-		clientID, err = common.PromptGetInput("Client ID", common.ValidateNonEmptyOpt)
+		clientID, err = common.PromptInput("Client ID:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}
 	}
 
 	if clientSecret == "" {
-		clientSecret, err = common.PromptGetInput("Client Secret", common.ValidateNonEmptyOpt)
+		clientSecret, err = common.PromptInput("Client Secret:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/database/create.go
+++ b/cmd/rig/cmd/database/create.go
@@ -13,7 +13,7 @@ import (
 func Create(ctx context.Context, cmd *cobra.Command, args []string, nc rig.Client) error {
 	var err error
 	if name == "" {
-		name, err = common.PromptGetInput("Database name:", common.ValidateNonEmptyOpt)
+		name, err = common.PromptInput("Database name:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/database/create_credential.go
+++ b/cmd/rig/cmd/database/create_credential.go
@@ -21,7 +21,7 @@ func CreateCredential(ctx context.Context, cmd *cobra.Command, args []string, nc
 	}
 
 	if name == "" {
-		name, err = common.PromptGetInput("Credential Name", common.ValidateNonEmptyOpt)
+		name, err = common.PromptInput("Credential Name:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/database/create_table.go
+++ b/cmd/rig/cmd/database/create_table.go
@@ -21,7 +21,7 @@ func CreateTable(ctx context.Context, cmd *cobra.Command, args []string, nc rig.
 	}
 
 	if name == "" {
-		name, err = common.PromptGetInput("Table Name", common.ValidateNonEmptyOpt)
+		name, err = common.PromptInput("Table Name:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/database/delete_credential.go
+++ b/cmd/rig/cmd/database/delete_credential.go
@@ -21,7 +21,7 @@ func DeleteCredential(ctx context.Context, cmd *cobra.Command, args []string, nc
 	}
 
 	if name == "" {
-		name, err = common.PromptGetInput("Credential Name", common.ValidateNonEmptyOpt)
+		name, err = common.PromptInput("Credential Name:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/database/delete_table.go
+++ b/cmd/rig/cmd/database/delete_table.go
@@ -21,7 +21,7 @@ func DeleteTable(ctx context.Context, cmd *cobra.Command, args []string, nc rig.
 	}
 
 	if name == "" {
-		name, err = common.PromptGetInput("Table Name", common.ValidateNonEmptyOpt)
+		name, err = common.PromptInput("Table Name:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/group/create.go
+++ b/cmd/rig/cmd/group/create.go
@@ -13,7 +13,7 @@ import (
 func GroupCreate(ctx context.Context, cmd *cobra.Command, args []string, nc rig.Client) error {
 	var err error
 	if name == "" {
-		name, err = common.PromptGetInput("Name:", common.ValidateNonEmptyOpt)
+		name, err = common.PromptInput("Name:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/group/update.go
+++ b/cmd/rig/cmd/group/update.go
@@ -87,7 +87,7 @@ func GroupUpdate(ctx context.Context, cmd *cobra.Command, args []string, nc rig.
 func promptGroupUpdate(f groupField, g *group.Group) (*group.Update, error) {
 	switch f {
 	case groupName:
-		name, err := common.PromptGetInput("Name:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(g.GetName()))
+		name, err := common.PromptInput("Name:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(g.GetName()))
 		if err != nil {
 			return nil, err
 		}
@@ -100,11 +100,11 @@ func promptGroupUpdate(f groupField, g *group.Group) (*group.Update, error) {
 			}, nil
 		}
 	case groupSetMetaData:
-		key, err := common.PromptGetInput("Key:", common.ValidateNonEmptyOpt)
+		key, err := common.PromptInput("Key:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return nil, err
 		}
-		value, err := common.PromptGetInput("Value:", common.ValidateNonEmptyOpt)
+		value, err := common.PromptInput("Value:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return nil, err
 		}
@@ -119,7 +119,7 @@ func promptGroupUpdate(f groupField, g *group.Group) (*group.Update, error) {
 		}, nil
 
 	case groupDeleteMetaData:
-		key, err := common.PromptGetInput("Key:", common.ValidateNonEmptyOpt)
+		key, err := common.PromptInput("Key:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/rig/cmd/project/create.go
+++ b/cmd/rig/cmd/project/create.go
@@ -15,7 +15,7 @@ import (
 func ProjectCreate(ctx context.Context, cmd *cobra.Command, args []string, nc rig.Client, cfg *cmd_config.Config) error {
 	if name == "" {
 		var err error
-		name, err = common.PromptGetInput("Project name:", common.ValidateNonEmptyOpt)
+		name, err = common.PromptInput("Project name:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/project/update_settings.go
+++ b/cmd/rig/cmd/project/update_settings.go
@@ -273,22 +273,22 @@ func promptDeleteDockerRegistry(s *settings.Settings) (*settings.Update, error) 
 }
 
 func promptAddDockerRegistry(s *settings.Settings) (*settings.Update, error) {
-	host, err := common.PromptGetInput("Enter host", common.ValidateNonEmptyOpt)
+	host, err := common.PromptInput("Enter host:", common.ValidateNonEmptyOpt)
 	if err != nil {
 		return nil, err
 	}
 
-	username, err := common.PromptGetInput("Enter username", common.ValidateNonEmptyOpt)
+	username, err := common.PromptInput("Enter username:", common.ValidateNonEmptyOpt)
 	if err != nil {
 		return nil, err
 	}
 
-	password, err := common.PromptGetInput("Enter password", common.ValidateNonEmptyOpt)
+	password, err := common.PromptInput("Enter password:", common.ValidateNonEmptyOpt)
 	if err != nil {
 		return nil, err
 	}
 
-	email, err := common.PromptGetInput("Enter email", common.ValidateEmailOpt)
+	email, err := common.PromptInput("Enter email:", common.ValidateEmailOpt)
 	if err != nil {
 		return nil, err
 	}
@@ -341,31 +341,31 @@ func promptEmailProviderFields(p *settings.EmailProvider, prov string) error {
 
 		switch res {
 		case emailProviderPublicKey.String():
-			key, err := common.PromptGetInput("Enter public key", common.ValidateNonEmptyOpt)
+			key, err := common.PromptInput("Enter public key:", common.ValidateNonEmptyOpt)
 			if err != nil {
 				return err
 			}
 			p.Credentials.PublicKey = key
 		case emailProviderPrivateKey.String():
-			key, err := common.PromptGetInput("Enter private key", common.ValidateNonEmptyOpt)
+			key, err := common.PromptInput("Enter private key:", common.ValidateNonEmptyOpt)
 			if err != nil {
 				return err
 			}
 			p.Credentials.PrivateKey = key
 		case emailProviderFromEmail.String():
-			email, err := common.PromptGetInput("Enter from email", common.ValidateEmailOpt, common.InputDefaultOpt(p.GetFrom()))
+			email, err := common.PromptInput("Enter from email:", common.ValidateEmailOpt, common.InputDefaultOpt(p.GetFrom()))
 			if err != nil {
 				return err
 			}
 			p.From = email
 		case emailProviderHost.String():
-			host, err := common.PromptGetInput("Enter host", common.ValidateNonEmptyOpt, common.InputDefaultOpt(p.GetInstance().GetSmtp().GetHost()))
+			host, err := common.PromptInput("Enter host:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(p.GetInstance().GetSmtp().GetHost()))
 			if err != nil {
 				return err
 			}
 			p.GetInstance().GetSmtp().Host = host
 		case emailProviderPort.String():
-			port, err := common.PromptGetInput("Enter port", common.ValidateNonEmptyOpt, common.InputDefaultOpt(strconv.Itoa(int(p.GetInstance().GetSmtp().GetPort()))))
+			port, err := common.PromptInput("Enter port:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(strconv.Itoa(int(p.GetInstance().GetSmtp().GetPort()))))
 			if err != nil {
 				return err
 			}
@@ -400,13 +400,13 @@ func promptTemplate(t *settings.Template) (*settings.Update, error) {
 
 		switch res {
 		case tempalteFieldSubject.String():
-			subject, err := common.PromptGetInput("Enter subject", common.ValidateNonEmptyOpt, common.InputDefaultOpt(t.GetSubject()))
+			subject, err := common.PromptInput("Enter subject:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(t.GetSubject()))
 			if err != nil {
 				return nil, err
 			}
 			t.Subject = subject
 		case templateFieldBody.String():
-			body, err := common.PromptGetInput("Enter body", common.ValidateNonEmptyOpt, common.InputDefaultOpt(t.GetBody()))
+			body, err := common.PromptInput("Enter body:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(t.GetBody()))
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/rig/cmd/service_account/create.go
+++ b/cmd/rig/cmd/service_account/create.go
@@ -15,7 +15,7 @@ func ServiceAccountCreate(ctx context.Context, cmd *cobra.Command, args []string
 	var err error
 
 	if name == "" {
-		name, err = common.PromptGetInput("Name:", common.ValidateNonEmptyOpt)
+		name, err = common.PromptInput("Name:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/service_account/delete.go
+++ b/cmd/rig/cmd/service_account/delete.go
@@ -20,7 +20,7 @@ func ServiceAccountDelete(ctx context.Context, cmd *cobra.Command, args []string
 	}
 
 	if id == "" {
-		id, err = common.PromptGetInput("ID:", common.ValidateNonEmptyOpt)
+		id, err = common.PromptInput("ID:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/storage/create_bucket.go
+++ b/cmd/rig/cmd/storage/create_bucket.go
@@ -64,7 +64,7 @@ func StorageCreateBucket(ctx context.Context, cmd *cobra.Command, args []string,
 	}
 
 	if name == "" {
-		name, err = common.PromptGetInput("Bucket name:", ValidateBucketNameOpt)
+		name, err = common.PromptInput("Bucket name:", ValidateBucketNameOpt)
 		if err != nil {
 			return err
 		}
@@ -73,7 +73,7 @@ func StorageCreateBucket(ctx context.Context, cmd *cobra.Command, args []string,
 	}
 
 	if providerBucketName == "" {
-		providerBucketName, err = common.PromptGetInput("Provider bucket name:", ValidateBucketNameOpt, common.InputDefaultOpt(name))
+		providerBucketName, err = common.PromptInput("Provider bucket name:", ValidateBucketNameOpt, common.InputDefaultOpt(name))
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/storage/create_provider.go
+++ b/cmd/rig/cmd/storage/create_provider.go
@@ -18,7 +18,7 @@ import (
 func StorageCreateProvider(ctx context.Context, cmd *cobra.Command, args []string, nc rig.Client) error {
 	var err error
 	if name == "" {
-		name, err = common.PromptGetInput("Provider identifier:", common.ValidateNonEmptyOpt)
+		name, err = common.PromptInput("Provider identifier:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}
@@ -73,7 +73,7 @@ func StorageCreateProvider(ctx context.Context, cmd *cobra.Command, args []strin
 		switch i {
 		case 0:
 			// GCS
-			path, err := common.PromptGetInput("Credentials Path:", common.ValidateNonEmptyOpt)
+			path, err := common.PromptInput("Credentials Path:", common.ValidateNonEmptyOpt)
 			if err != nil {
 				return err
 			}
@@ -84,17 +84,17 @@ func StorageCreateProvider(ctx context.Context, cmd *cobra.Command, args []strin
 			}
 		case 1:
 			// S3
-			accessKey, err := common.PromptGetInput("Access Key:", common.ValidateNonEmptyOpt)
+			accessKey, err := common.PromptInput("Access Key:", common.ValidateNonEmptyOpt)
 			if err != nil {
 				return err
 			}
 
-			secretKey, err := common.PromptGetInput("Secret Key:", common.ValidateNonEmptyOpt)
+			secretKey, err := common.PromptInput("Secret Key:", common.ValidateNonEmptyOpt)
 			if err != nil {
 				return err
 			}
 
-			region, err := common.PromptGetInput("Region:", common.ValidateNonEmptyOpt)
+			region, err := common.PromptInput("Region:", common.ValidateNonEmptyOpt)
 			if err != nil {
 				return err
 			}
@@ -114,17 +114,17 @@ func StorageCreateProvider(ctx context.Context, cmd *cobra.Command, args []strin
 		case 2:
 			// Minio
 
-			accessKey, err := common.PromptGetInput("Access Key:", common.ValidateNonEmptyOpt)
+			accessKey, err := common.PromptInput("Access Key:", common.ValidateNonEmptyOpt)
 			if err != nil {
 				return err
 			}
 
-			secretKey, err := common.PromptGetInput("Secret Key:", common.ValidateNonEmptyOpt)
+			secretKey, err := common.PromptInput("Secret Key:", common.ValidateNonEmptyOpt)
 			if err != nil {
 				return err
 			}
 
-			endpoint, err := common.PromptGetInput("Endpoint:", common.ValidateNonEmptyOpt)
+			endpoint, err := common.PromptInput("Endpoint:", common.ValidateNonEmptyOpt)
 			if err != nil {
 				return err
 			}

--- a/cmd/rig/cmd/storage/delete_bucket.go
+++ b/cmd/rig/cmd/storage/delete_bucket.go
@@ -17,7 +17,7 @@ func StorageDeleteBucket(ctx context.Context, cmd *cobra.Command, args []string,
 	var bucket string
 	var err error
 	if len(args) < 1 {
-		bucket, err = common.PromptGetInput("Bucket name:", ValidateBucketNameOpt)
+		bucket, err = common.PromptInput("Bucket name:", ValidateBucketNameOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/storage/delete_object.go
+++ b/cmd/rig/cmd/storage/delete_object.go
@@ -16,7 +16,7 @@ func StorageDeleteObject(ctx context.Context, cmd *cobra.Command, args []string,
 	var path string
 	var err error
 	if len(args) < 1 {
-		path, err = common.PromptGetInput("Object path:", common.ValidateNonEmptyOpt)
+		path, err = common.PromptInput("Object path:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/storage/get_bucket.go
+++ b/cmd/rig/cmd/storage/get_bucket.go
@@ -15,7 +15,7 @@ func StorageGetBucket(ctx context.Context, cmd *cobra.Command, args []string, nc
 	var bucket string
 	var err error
 	if len(args) < 1 {
-		bucket, err = common.PromptGetInput("Bucket name:", ValidateBucketNameOpt)
+		bucket, err = common.PromptInput("Bucket name:", ValidateBucketNameOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/storage/get_object.go
+++ b/cmd/rig/cmd/storage/get_object.go
@@ -16,7 +16,7 @@ func StorageGetObject(ctx context.Context, cmd *cobra.Command, args []string, nc
 	var path string
 	var err error
 	if len(args) < 1 {
-		path, err = common.PromptGetInput("Object path:", common.ValidateNonEmptyOpt)
+		path, err = common.PromptInput("Object path:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/storage/unlink_bucket.go
+++ b/cmd/rig/cmd/storage/unlink_bucket.go
@@ -17,7 +17,7 @@ func StorageUnlinkBucket(ctx context.Context, cmd *cobra.Command, args []string,
 	var bucket string
 	var err error
 	if len(args) < 1 {
-		bucket, err = common.PromptGetInput("Bucket name:", ValidateBucketNameOpt)
+		bucket, err = common.PromptInput("Bucket name:", ValidateBucketNameOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/user/migrate.go
+++ b/cmd/rig/cmd/user/migrate.go
@@ -121,7 +121,7 @@ func migrateFromFirebase(ctx context.Context, nc rig.Client) error {
 func migrateFromFirebaseCredentials(ctx context.Context, nc rig.Client) error {
 	var err error
 	if credFilePath == "" {
-		credFilePath, err = common.PromptGetInput("Credentials Path:", common.ValidateNonEmptyOpt)
+		credFilePath, err = common.PromptInput("Credentials Path:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}
@@ -159,7 +159,7 @@ func migrateFromFirebaseCredentials(ctx context.Context, nc rig.Client) error {
 
 	// input hashing key for password
 	if hashingKey == "" {
-		hashingKey, err = common.PromptGetInput("Hashing Key:", common.ValidateNonEmptyOpt)
+		hashingKey, err = common.PromptInput("Hashing Key:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}
@@ -262,7 +262,7 @@ func migrateFromFirebaseCredentials(ctx context.Context, nc rig.Client) error {
 func migrateFromFirebaseUsersFile(ctx context.Context, nc rig.Client) error {
 	var err error
 	if usersFilePath == "" {
-		usersFilePath, err = common.PromptGetInput("users.json path:", common.ValidateNonEmptyOpt)
+		usersFilePath, err = common.PromptInput("users.json path:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}
@@ -289,7 +289,7 @@ func migrateFromFirebaseUsersFile(ctx context.Context, nc rig.Client) error {
 
 	// input hashing key for password
 	if hashingKey == "" {
-		hashingKey, err = common.PromptGetInput("Hashing Key:", common.ValidateNonEmptyOpt)
+		hashingKey, err = common.PromptInput("Hashing Key:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/user/update.go
+++ b/cmd/rig/cmd/user/update.go
@@ -165,7 +165,7 @@ func promptUserUpdate(f userField, u *user.User) (*user.Update, error) {
 	switch f {
 	case userEmail:
 		defEmail := u.GetUserInfo().GetEmail()
-		email, err := common.PromptGetInput("Email:", common.ValidateEmailOpt, common.InputDefaultOpt(defEmail))
+		email, err := common.PromptInput("Email:", common.ValidateEmailOpt, common.InputDefaultOpt(defEmail))
 		if err != nil {
 			return nil, nil
 		}
@@ -179,7 +179,7 @@ func promptUserUpdate(f userField, u *user.User) (*user.Update, error) {
 		}
 	case userUsername:
 		defUsername := u.GetUserInfo().GetUsername()
-		username, err := common.PromptGetInput("Username:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(defUsername))
+		username, err := common.PromptInput("Username:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(defUsername))
 		if err != nil {
 			return nil, nil
 		}
@@ -193,7 +193,7 @@ func promptUserUpdate(f userField, u *user.User) (*user.Update, error) {
 		}
 	case userPhoneNumber:
 		defPhone := u.GetUserInfo().GetPhoneNumber()
-		phone, err := common.PromptGetInput("Phone:", common.ValidatePhoneOpt, common.InputDefaultOpt(defPhone))
+		phone, err := common.PromptInput("Phone:", common.ValidatePhoneOpt, common.InputDefaultOpt(defPhone))
 		if err != nil {
 			return nil, nil
 		}
@@ -206,7 +206,7 @@ func promptUserUpdate(f userField, u *user.User) (*user.Update, error) {
 			}, nil
 		}
 	case userPassword:
-		password, err := common.GetPasswordPrompt("Password:")
+		password, err := common.PromptPassword("Password:")
 		if err != nil {
 			return nil, nil
 		}
@@ -217,7 +217,7 @@ func promptUserUpdate(f userField, u *user.User) (*user.Update, error) {
 		}, nil
 	case userIsEmailVerified:
 		defIsEmailVerified := strconv.FormatBool(u.GetIsEmailVerified())
-		isEmailVerified, err := common.PromptGetInput("Is email verified:", common.BoolValidateOpt, common.InputDefaultOpt(defIsEmailVerified))
+		isEmailVerified, err := common.PromptInput("Is email verified:", common.BoolValidateOpt, common.InputDefaultOpt(defIsEmailVerified))
 		if err != nil {
 			return nil, nil
 		}
@@ -230,7 +230,7 @@ func promptUserUpdate(f userField, u *user.User) (*user.Update, error) {
 		}
 	case userIsPhoneVerified:
 		defIsPhoneVerified := strconv.FormatBool(u.GetIsPhoneVerified())
-		isPhoneVerified, err := common.PromptGetInput("Is phone verified:", common.BoolValidateOpt, common.InputDefaultOpt(defIsPhoneVerified))
+		isPhoneVerified, err := common.PromptInput("Is phone verified:", common.BoolValidateOpt, common.InputDefaultOpt(defIsPhoneVerified))
 		if err != nil {
 			return nil, nil
 		}
@@ -252,11 +252,11 @@ func promptUserUpdate(f userField, u *user.User) (*user.Update, error) {
 		}
 		return u, err
 	case userSetMetaData:
-		key, err := common.PromptGetInput("Key:", common.ValidateNonEmptyOpt)
+		key, err := common.PromptInput("Key:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return nil, nil
 		}
-		value, err := common.PromptGetInput("Value:", common.ValidateNonEmptyOpt)
+		value, err := common.PromptInput("Value:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return nil, nil
 		}
@@ -269,7 +269,7 @@ func promptUserUpdate(f userField, u *user.User) (*user.Update, error) {
 			},
 		}, nil
 	case userDeleteMetaData:
-		key, err := common.PromptGetInput("Key:", common.ValidateNonEmptyOpt)
+		key, err := common.PromptInput("Key:", common.ValidateNonEmptyOpt)
 		if err != nil {
 			return nil, nil
 		}
@@ -329,7 +329,7 @@ func promptUserProfileUpdate(f userProfileField, p *user.Profile) error {
 	switch f {
 	case userProfileFirstName:
 		defFirstName := p.GetFirstName()
-		firstName, err := common.PromptGetInput("First name:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(defFirstName))
+		firstName, err := common.PromptInput("First name:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(defFirstName))
 		if err != nil {
 			return err
 		}
@@ -338,7 +338,7 @@ func promptUserProfileUpdate(f userProfileField, p *user.Profile) error {
 		}
 	case userProfileLastName:
 		defLastName := p.GetLastName()
-		lastName, err := common.PromptGetInput("Last name:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(defLastName))
+		lastName, err := common.PromptInput("Last name:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(defLastName))
 		if err != nil {
 			return err
 		}
@@ -347,7 +347,7 @@ func promptUserProfileUpdate(f userProfileField, p *user.Profile) error {
 		}
 	case userProfilePreferredLanguage:
 		defPreferredLanguage := p.GetPreferredLanguage()
-		preferredLanguage, err := common.PromptGetInput("Preferred language:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(defPreferredLanguage))
+		preferredLanguage, err := common.PromptInput("Preferred language:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(defPreferredLanguage))
 		if err != nil {
 			return err
 		}
@@ -356,7 +356,7 @@ func promptUserProfileUpdate(f userProfileField, p *user.Profile) error {
 		}
 	case userProfileCountry:
 		defCountry := p.GetCountry()
-		country, err := common.PromptGetInput("Country:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(defCountry))
+		country, err := common.PromptInput("Country:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(defCountry))
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/user/update_settings.go
+++ b/cmd/rig/cmd/user/update_settings.go
@@ -193,7 +193,7 @@ func promptSettingsUpdate(f settingsField, s *settings.Settings) ([]*settings.Up
 	switch f {
 	case settingsAllowRegister:
 		defAllowRegister := strconv.FormatBool(s.GetAllowRegister())
-		allowRegister, err := common.PromptGetInput("Allow Register:", common.BoolValidateOpt, common.InputDefaultOpt(defAllowRegister))
+		allowRegister, err := common.PromptInput("Allow Register:", common.BoolValidateOpt, common.InputDefaultOpt(defAllowRegister))
 		if err != nil {
 			return nil, nil
 		}
@@ -206,7 +206,7 @@ func promptSettingsUpdate(f settingsField, s *settings.Settings) ([]*settings.Up
 		}, nil
 	case settingsIsVerifiedEmailRequired:
 		defIsVerifiedEmailRequired := strconv.FormatBool(s.GetIsVerifiedEmailRequired())
-		isVerifiedEmailRequired, err := common.PromptGetInput("Verify Email Required:", common.BoolValidateOpt, common.InputDefaultOpt(defIsVerifiedEmailRequired))
+		isVerifiedEmailRequired, err := common.PromptInput("Verify Email Required:", common.BoolValidateOpt, common.InputDefaultOpt(defIsVerifiedEmailRequired))
 		if err != nil {
 			return nil, nil
 		}
@@ -219,7 +219,7 @@ func promptSettingsUpdate(f settingsField, s *settings.Settings) ([]*settings.Up
 		}, nil
 	case settingsIsVerifiedPhoneRequired:
 		defIsVerifiedPhoneRequired := strconv.FormatBool(s.GetIsVerifiedPhoneRequired())
-		isVerifiedPhoneRequired, err := common.PromptGetInput("Verify Phone Required:", common.BoolValidateOpt, common.InputDefaultOpt(defIsVerifiedPhoneRequired))
+		isVerifiedPhoneRequired, err := common.PromptInput("Verify Phone Required:", common.BoolValidateOpt, common.InputDefaultOpt(defIsVerifiedPhoneRequired))
 		if err != nil {
 			return nil, nil
 		}
@@ -232,7 +232,7 @@ func promptSettingsUpdate(f settingsField, s *settings.Settings) ([]*settings.Up
 		}, nil
 	case settingsAccessTokenTTL:
 		defAccessTokenTtl := strconv.Itoa(int(s.GetAccessTokenTtl().AsDuration().Minutes()))
-		accessTokenTtl, err := common.PromptGetInput("Access Token TTL (minutes):", common.ValidateIntOpt, common.InputDefaultOpt(defAccessTokenTtl))
+		accessTokenTtl, err := common.PromptInput("Access Token TTL (minutes):", common.ValidateIntOpt, common.InputDefaultOpt(defAccessTokenTtl))
 		if err != nil {
 			return nil, nil
 		}
@@ -249,7 +249,7 @@ func promptSettingsUpdate(f settingsField, s *settings.Settings) ([]*settings.Up
 		}, err
 	case settingsRefreshTokenTTL:
 		defRefreshTokenTtl := strconv.Itoa(int(s.GetRefreshTokenTtl().AsDuration().Hours()))
-		refreshTokenTtl, err := common.PromptGetInput("Refresh Token TTL (hours):", common.ValidateIntOpt, common.InputDefaultOpt(defRefreshTokenTtl))
+		refreshTokenTtl, err := common.PromptInput("Refresh Token TTL (hours):", common.ValidateIntOpt, common.InputDefaultOpt(defRefreshTokenTtl))
 		if err != nil {
 			return nil, nil
 		}
@@ -266,7 +266,7 @@ func promptSettingsUpdate(f settingsField, s *settings.Settings) ([]*settings.Up
 		}, nil
 	case settingsVerificationCodeTTL:
 		defVerificationCodeTtl := strconv.Itoa(int(s.GetVerificationCodeTtl().AsDuration().Minutes()))
-		verificationCodeTtl, err := common.PromptGetInput("Verification Code TTL (minutes):", common.ValidateIntOpt, common.InputDefaultOpt(defVerificationCodeTtl))
+		verificationCodeTtl, err := common.PromptInput("Verification Code TTL (minutes):", common.ValidateIntOpt, common.InputDefaultOpt(defVerificationCodeTtl))
 		if err != nil {
 			return nil, nil
 		}
@@ -320,7 +320,7 @@ func getPasswordHashingUpdate(psh *model.HashingConfig) (*settings.Update, error
 		}
 
 		bcrypt := &model.BcryptHashingConfig{}
-		cost, err := common.PromptGetInput("Cost:", common.ValidateIntOpt, common.InputDefaultOpt(defCost))
+		cost, err := common.PromptInput("Cost:", common.ValidateIntOpt, common.InputDefaultOpt(defCost))
 		if err != nil {
 			return nil, err
 		}
@@ -352,40 +352,40 @@ func getPasswordHashingUpdate(psh *model.HashingConfig) (*settings.Update, error
 		}
 
 		scrypt := &model.ScryptHashingConfig{}
-		key, err := common.PromptGetInput("Key:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(defKey))
+		key, err := common.PromptInput("Key:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(defKey))
 		if err != nil {
 			return nil, err
 		}
 		scrypt.SignerKey = key
 
-		saltSeparator, err := common.PromptGetInput("Salt Separator:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(defSaltSeparator))
+		saltSeparator, err := common.PromptInput("Salt Separator:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(defSaltSeparator))
 		if err != nil {
 			return nil, err
 		}
 		scrypt.SaltSeparator = saltSeparator
 
-		rounds, err := common.PromptGetInput("Rounds:", common.ValidateIntOpt, common.InputDefaultOpt(defRounds))
+		rounds, err := common.PromptInput("Rounds:", common.ValidateIntOpt, common.InputDefaultOpt(defRounds))
 		if err != nil {
 			return nil, err
 		}
 		roundsInt, _ := strconv.Atoi(rounds)
 		scrypt.Rounds = int32(roundsInt)
 
-		memCost, err := common.PromptGetInput("Memory Cost:", common.ValidateIntOpt, common.InputDefaultOpt(defMemCost))
+		memCost, err := common.PromptInput("Memory Cost:", common.ValidateIntOpt, common.InputDefaultOpt(defMemCost))
 		if err != nil {
 			return nil, err
 		}
 		memCostInt, _ := strconv.Atoi(memCost)
 		scrypt.MemCost = int32(memCostInt)
 
-		parallelism, err := common.PromptGetInput("Parallelism:", common.ValidateIntOpt, common.InputDefaultOpt(defParallelism))
+		parallelism, err := common.PromptInput("Parallelism:", common.ValidateIntOpt, common.InputDefaultOpt(defParallelism))
 		if err != nil {
 			return nil, err
 		}
 		parallelismInt, _ := strconv.Atoi(parallelism)
 		scrypt.P = int32(parallelismInt)
 
-		keyLength, err := common.PromptGetInput("Key Length:", common.ValidateIntOpt, common.InputDefaultOpt(defKeyLength))
+		keyLength, err := common.PromptInput("Key Length:", common.ValidateIntOpt, common.InputDefaultOpt(defKeyLength))
 		if err != nil {
 			return nil, err
 		}
@@ -543,27 +543,27 @@ func getOauthSettingsUpdate(current *settings.OauthSettings) ([]*settings.Update
 func updateOauthProvider(u *settings.OauthProviderUpdate) (*settings.OauthProviderUpdate, error) {
 	fmt.Println("Current Oauth Provider Settings: ", u)
 
-	allowLogin, err := common.PromptGetInput("Allow Login:", common.BoolValidateOpt, common.InputDefaultOpt(strconv.FormatBool(u.GetAllowLogin())))
+	allowLogin, err := common.PromptInput("Allow Login:", common.BoolValidateOpt, common.InputDefaultOpt(strconv.FormatBool(u.GetAllowLogin())))
 	if err != nil {
 		return nil, err
 	}
 	allowLoginBool, _ := strconv.ParseBool(allowLogin)
 	u.AllowLogin = allowLoginBool
 
-	allowRegister, err := common.PromptGetInput("Allow Register:", common.BoolValidateOpt, common.InputDefaultOpt(strconv.FormatBool(u.GetAllowRegister())))
+	allowRegister, err := common.PromptInput("Allow Register:", common.BoolValidateOpt, common.InputDefaultOpt(strconv.FormatBool(u.GetAllowRegister())))
 	if err != nil {
 		return nil, err
 	}
 	allowRegisterBool, _ := strconv.ParseBool(allowRegister)
 	u.AllowRegister = allowRegisterBool
 
-	clientID, err := common.PromptGetInput("Client ID:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(u.GetCredentials().GetPublicKey()))
+	clientID, err := common.PromptInput("Client ID:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(u.GetCredentials().GetPublicKey()))
 	if err != nil {
 		return nil, err
 	}
 	u.Credentials.PublicKey = clientID
 
-	clientSecret, err := common.PromptGetInput("Client Secret:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(u.Credentials.GetPrivateKey()))
+	clientSecret, err := common.PromptInput("Client Secret:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(u.Credentials.GetPrivateKey()))
 	if err != nil {
 		return nil, err
 	}
@@ -591,7 +591,7 @@ func updateCallbacks(current []string) []string {
 			break
 		}
 		if res == "Add" {
-			callback, err := common.PromptGetInput("Callback:", common.ValidateNonEmptyOpt)
+			callback, err := common.PromptInput("Callback:", common.ValidateNonEmptyOpt)
 			if err != nil {
 				fmt.Println(err.Error())
 				continue
@@ -608,7 +608,7 @@ func updateCallbacks(current []string) []string {
 				fmt.Println(err.Error())
 				continue
 			}
-			callback, err := common.PromptGetInput("Callback:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(res))
+			callback, err := common.PromptInput("Callback:", common.ValidateNonEmptyOpt, common.InputDefaultOpt(res))
 			if err != nil {
 				fmt.Println(err.Error())
 				continue

--- a/proto/rig/api/v1/capsule/service.proto
+++ b/proto/rig/api/v1/capsule/service.proto
@@ -55,6 +55,8 @@ service Service {
   rpc ListEvents(ListEventsRequest) returns (ListEventsResponse) {}
   // Get metrics for a capsule
   rpc CapsuleMetrics(CapsuleMetricsRequest) returns (CapsuleMetricsResponse) {}
+
+    // rpc UpdateResources(
 }
 
 message CreateRequest {


### PR DESCRIPTION
 - Added missing OmitUser to `context` commands
 - Standardized how/if we add '?' at the end of PromptConfirm
 - Standardized how/if we add ':' at the end of PromptGetInput
 - Renamed PromptGetInput -> PromptInput, GetPasswordPrompt -> PromptPassword
   for consistency with the other Prompt functions
