### PR TITLE
✨ Add CRD webhook support 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,8 +130,8 @@ docker-compose-down: ## 🐳 Stop docker-compose
 	docker compose -f ./deploy/docker-compose/docker-compose.yaml down
 
 KUBECTX ?= kind-rig
-KUBECTL ?= kubectl --context $(KUBECTX)
-HELM ?= helm --kube-context $(KUBECTX)
+export KUBECTL ?= kubectl --context $(KUBECTX)
+export HELM ?= helm --kube-context $(KUBECTX)
 
 .PHONY: deploy
 deploy: ## 🚀 Deploy to k8s context defined by $KUBECTX (default: kind-rig)
@@ -147,8 +147,7 @@ deploy: ## 🚀 Deploy to k8s context defined by $KUBECTX (default: kind-rig)
 
 .PHONY: kind-create
 kind-create: kind ## 🐋 Create kind cluster with rig dependencies
-	$(KIND) get clusters | grep '^rig$$' || \
-		./deploy/kind/create.sh $(KIND)
+	./deploy/kind/create.sh
 
 .PHONY: kind-load
 kind-load: kind docker ## 🐋 Load docker image into kind cluster
@@ -235,7 +234,7 @@ goreleaser: ## 📦 Download goreleaser locally if necessary.
 	(test -s $(GORELEASER) && $(GORELEASER) --version | grep "$(GORELEASER_GO_MOD_VERSION)") || \
 	(cd tools && GOBIN=$(TOOLSBIN) go install github.com/goreleaser/goreleaser)
 
-KIND ?= $(TOOLSBIN)/kind
+export KIND ?= $(TOOLSBIN)/kind
 KIND_GO_MOD_VERSION ?= $(shell cat tools/go.mod | grep -E "sigs.k8s.io/kind" | cut -d ' ' -f2)
 
 .PHONY: kind

--- a/deploy/charts/rig/templates/certmanager.yaml
+++ b/deploy/charts/rig/templates/certmanager.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.webhooks.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "rig.fullname" . }}
+  labels: {{ include "rig.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "rig.fullname" . }}-webhook
+  labels: {{ include "rig.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+  - {{ include "rig.fullname" . }}-svc.{{ .Release.Namespace }}.svc
+  - {{ include "rig.fullname" . }}-svc.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ include "rig.fullname" . }}
+  secretName: {{ include "rig.fullname" . }}-webhook-cert
+{{- end }}

--- a/deploy/charts/rig/templates/crd-capsules.yaml
+++ b/deploy/charts/rig/templates/crd-capsules.yaml
@@ -1,0 +1,190 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.13.0
+  name: capsules.rig.dev
+spec:
+  group: rig.dev
+  names:
+    kind: Capsule
+    listKind: CapsuleList
+    plural: capsules
+    singular: capsule
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Capsule is the Schema for the capsules API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CapsuleSpec defines the desired state of Capsule
+            properties:
+              args:
+                items:
+                  type: string
+                type: array
+              command:
+                type: string
+              files:
+                items:
+                  description: File defines a mounted file and where to retrieve the
+                    contents from
+                  properties:
+                    configMap:
+                      description: FileContentRef defines the name of a config resource
+                        and the key which from which to retrieve the contents
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    path:
+                      type: string
+                    secret:
+                      description: FileContentRef defines the name of a config resource
+                        and the key which from which to retrieve the contents
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                  required:
+                  - path
+                  type: object
+                type: array
+              image:
+                type: string
+              imagePullSecret:
+                description: LocalObjectReference contains enough information to let
+                  you locate the referenced object inside the same namespace.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              interfaces:
+                items:
+                  description: CapsuleInterface defines an interface for a capsule
+                  properties:
+                    name:
+                      type: string
+                    port:
+                      format: int32
+                      type: integer
+                    public:
+                      description: CapsulePublicInterface defines how to publicly
+                        expose the interface
+                      properties:
+                        ingress:
+                          description: CapsuleInterfaceIngress defines that the interface
+                            should be exposed as http ingress
+                          properties:
+                            host:
+                              type: string
+                          required:
+                          - host
+                          type: object
+                        loadBalancer:
+                          description: CapsuleInterfaceLoadBalancer defines that the
+                            interface should be exposed as a L4 loadbalancer
+                          properties:
+                            port:
+                              format: int32
+                              type: integer
+                          required:
+                          - port
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  - port
+                  type: object
+                type: array
+              replicas:
+                format: int32
+                type: integer
+              resources:
+                description: ResourceRequirements describes the compute resource requirements.
+                properties:
+                  claims:
+                    description: "Claims lists the names of resources, defined in
+                      spec.resourceClaims, that are used by this container. \n This
+                      is an alpha field and requires enabling the DynamicResourceAllocation
+                      feature gate. \n This field is immutable. It can only be set
+                      for containers."
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: Name must match the name of one entry in pod.spec.resourceClaims
+                            of the Pod where this field is used. It makes that resource
+                            available inside a container.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+            required:
+            - image
+            - replicas
+            type: object
+          status:
+            description: CapsuleStatus defines the observed state of Capsule
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/charts/rig/templates/deployment.yaml
+++ b/deploy/charts/rig/templates/deployment.yaml
@@ -30,6 +30,11 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+            {{- if .Values.webhooks.enabled }}
+            - name: webhooks
+              containerPort: 9443
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /api/v1/status
@@ -45,10 +50,20 @@ spec:
             - name: config
               mountPath: /etc/rig
               readOnly: true
+            {{- if .Values.webhooks.enabled }}
+            - name: webhook-cert
+              mountPath: /tmp/k8s-webhook-server/serving-certs
+            {{- end }}
       volumes:
         - name: config
           secret:
             secretName: {{ include "rig.secretName" . }}
+        {{- if .Values.webhooks.enabled }}
+        - name: webhook-cert
+          secret:
+            defaultMode: 420
+            secretName: {{ include "rig.fullname" . }}-webhook-cert
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/charts/rig/templates/service.yaml
+++ b/deploy/charts/rig/templates/service.yaml
@@ -6,9 +6,14 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
+    - name: http
+      port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
-      name: http
-  selector:
-    {{- include "rig.selectorLabels" . | nindent 4 }}
+    {{- if .Values.webhooks.enabled }}
+    - name: webhooks
+      port: 9443
+      targetPort: webhooks
+      protocol: TCP
+    {{- end }}
+  selector: {{ include "rig.selectorLabels" . | nindent 4 }}

--- a/deploy/charts/rig/templates/webhookconfiguration.yaml
+++ b/deploy/charts/rig/templates/webhookconfiguration.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.webhooks.enabled }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "rig.fullname" . }}
+  labels: {{ include "rig.labels" . | nindent 4 }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "rig.fullname" . }}-webhook
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "rig.fullname" . }}-svc
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-rig-dev-v1alpha1-capsule
+      port: 9443
+  failurePolicy: Fail
+  name: mcapsule.kb.io
+  rules:
+  - apiGroups:
+    - rig.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - capsules
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "rig.fullname" . }}
+  labels: {{ include "rig.labels" . | nindent 4 }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "rig.fullname" . }}-webhook
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ include "rig.fullname" . }}-svc
+      namespace: {{ .Release.Namespace }}
+      path: /validate-rig-dev-v1alpha1-capsule
+      port: 9443
+  failurePolicy: Fail
+  name: vcapsule.kb.io
+  rules:
+  - apiGroups:
+    - rig.dev
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - capsules
+  sideEffects: None
+{{- end }}

--- a/deploy/charts/rig/values.yaml
+++ b/deploy/charts/rig/values.yaml
@@ -98,6 +98,9 @@ mongodb:
     className: ""
     size: 10Gi
 
+webhooks:
+  enabled: true
+
 # Rig holds configuration for the rig server. This is used for generating
 # the rig-server config file.
 rig:

--- a/deploy/kind/create.sh
+++ b/deploy/kind/create.sh
@@ -1,6 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -e
 
-cat <<EOF | $1 create cluster --name rig --config=-
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+
+KIND="${KIND:=kind}"
+KUBECTL="${KUBECTL:=kubectl --context kind-rig}"
+HELM="${HELM:=helm --kube-context kind-rig}"
+
+# Create kind cluster
+${KIND} get clusters | grep "^rig$" || \
+    cat <<EOF | ${KIND} create cluster --name rig --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
@@ -11,3 +20,30 @@ nodes:
     listenAddress: "127.0.0.1"
     protocol: TCP
 EOF
+
+# Ensure rig-system namespace exists
+${KUBECTL} get namespace rig-system || \
+    ${KUBECTL} create namespace rig-system
+
+# Install docker registry in rig-system namespace
+${KUBECTL} apply -n rig-system \
+    -f "${parent_path}/../registry/registry.yaml"
+
+# Ensure required repositories are available
+${HELM} repo list | grep '^jetstack\s*https://charts.jetstack.io\s*$' || \
+    ${HELM} repo add jetstack https://charts.jetstack.io
+${HELM} repo list | grep '^metrics-server\s*https://kubernetes-sigs.github.io/metrics-server\s*$' || \
+    ${HELM} repo add metrics-server https://kubernetes-sigs.github.io/metrics-server
+${HELM} repo update
+
+# Install cert-manager
+${HELM} upgrade --install cert-manager jetstack/cert-manager \
+    --namespace cert-manager \
+    --create-namespace \
+    --version v1.13.0 \
+    --set installCRDs=true
+
+# Install metrics-server
+${HELM} upgrade --install metrics-server metrics-server/metrics-server \
+    --namespace kube-system \
+    --set args={--kubelet-insecure-tls}

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -34,6 +34,9 @@ func newDefault() Config {
 			Docker: ClientDocker{
 				Host: "",
 			},
+			Kubernetes: ClientKubernetes{
+				WebhooksEnabled: true,
+			},
 			Mailjet: ClientMailjet{
 				From:      "",
 				APIKey:    "",

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -30,12 +30,13 @@ type AuthJWT struct {
 }
 
 type Client struct {
-	Postgres ClientPostgres `mapstructure:"postgres"`
-	Mongo    ClientMongo    `mapstructure:"mongo"`
-	Minio    ClientMinio    `mapstructure:"minio"`
-	Docker   ClientDocker   `mapstructure:"docker"`
-	Mailjet  ClientMailjet  `mapstructure:"mailjet"`
-	SMTP     ClientSMTP     `mapstructure:"smtp"`
+	Postgres   ClientPostgres   `mapstructure:"postgres"`
+	Mongo      ClientMongo      `mapstructure:"mongo"`
+	Minio      ClientMinio      `mapstructure:"minio"`
+	Docker     ClientDocker     `mapstructure:"docker"`
+	Kubernetes ClientKubernetes `mapstructure:"kubernetes"`
+	Mailjet    ClientMailjet    `mapstructure:"mailjet"`
+	SMTP       ClientSMTP       `mapstructure:"smtp"`
 }
 
 type ClientSMTP struct {
@@ -66,6 +67,10 @@ type ClientMinio struct {
 
 type ClientDocker struct {
 	Host string `mapstructure:"host"`
+}
+
+type ClientKubernetes struct {
+	WebhooksEnabled bool `mapstructure:"webhooksEnabled"`
 }
 
 type ClientMailjet struct {

--- a/test/integration/controller/capsule_controller_test.go
+++ b/test/integration/controller/capsule_controller_test.go
@@ -26,8 +26,9 @@ import (
 
 	"github.com/rigdev/rig/internal/controller"
 	"github.com/rigdev/rig/pkg/api/v1alpha1"
-	rigdevv1alpha1 "github.com/rigdev/rig/pkg/api/v1alpha1"
 	"github.com/rigdev/rig/pkg/ptr"
+
+	rigdevv1alpha1 "github.com/rigdev/rig/pkg/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
- Add `webhooks.enabled` value in chart and configure webhook related
  resources based on this.
- Add CRD to chart
- Improve `deploy/kind/create.sh`: Add commands which installs docker registry,
  cert-manager and metrics-server in the cluster.
- Add rig config for kubernetes client, so that we can toggle wether or
  not to run webhooks