### PR TITLE
CLI: Add --remote flag to create-build and deploy

### DIFF
--- a/cmd/rig/cmd/capsule/create_build.go
+++ b/cmd/rig/cmd/capsule/create_build.go
@@ -13,14 +13,16 @@ import (
 
 func CapsuleCreateBuild(ctx context.Context, cmd *cobra.Command, args []string, capsuleID CapsuleID, nc rig.Client, cfg *cmd_config.Config, dockerClient *client.Client) error {
 	var err error
+
+	imageRef := imageRefFromFlags()
 	if image == "" {
-		image, err = promptForImage(ctx, dockerClient)
+		imageRef, err = promptForImage(ctx, dockerClient)
 		if err != nil {
 			return err
 		}
 	}
 
-	buildID, err := createBuild(ctx, nc, capsuleID, dockerClient, image)
+	buildID, err := createBuild(ctx, nc, capsuleID, dockerClient, imageRef)
 	if err != nil {
 		return err
 	}

--- a/cmd/rig/cmd/capsule/setup.go
+++ b/cmd/rig/cmd/capsule/setup.go
@@ -26,6 +26,7 @@ var (
 	interactive    bool
 	outputJSON     bool
 	skipImageCheck bool
+	remote         bool
 )
 
 var (
@@ -71,6 +72,7 @@ func Setup(parent *cobra.Command) {
 	createBuild.Flags().StringVarP(&image, "image", "i", "", "image to use for the build")
 	createBuild.Flags().BoolVarP(&deploy, "deploy", "d", false, "deploy build after successful creation")
 	createBuild.Flags().BoolVarP(&skipImageCheck, "skip-image-check", "s", false, "skip validating that the docker image exists")
+	createBuild.Flags().BoolVarP(&remote, "remote", "r", false, "Rig will not look for the image locally but assumes it from a remote registry. If not set, Rig will search locally and then remotely")
 	capsule.AddCommand(createBuild)
 
 	deploy := &cobra.Command{
@@ -85,6 +87,7 @@ Not both --build-id and --image can be given`,
 	}
 	deploy.Flags().StringVarP(&buildID, "build-id", "b", "", "rig build id to deploy")
 	deploy.Flags().StringVarP(&image, "image", "i", "", "docker image to deploy. Will create a new rig-build from the image if it doesn't exist")
+	deploy.Flags().BoolVarP(&remote, "remote", "r", false, "if --image is also given, Rig will assume the image is from a remote registry. If not set, Rig will search locally and then remotely")
 	capsule.AddCommand(deploy)
 
 	scale := &cobra.Command{


### PR DESCRIPTION
The flag specifies if an image should not be searched for locally.
Sometimes you have a remote image also pulled locally. In that case,
you might not want to refer to the local one (which using a dev-registry
would unnecessarily be pushed into the dev-reg if considered a local image).
