### PR TITLE
🐛 Fix make chart deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@
 # dependencies
 go.work.sum
 
+# helm charts
+deploy/charts/*/Chart.lock
+deploy/charts/*/charts
+
 # at some point we might want to commit this so that rig can be installed via
 # kustomize
 /deploy/kustomize

--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,8 @@ KUBECTX ?= kind-rig
 export KUBECTL ?= kubectl --context $(KUBECTX)
 export HELM ?= helm --kube-context $(KUBECTX)
 
-.PHONY: deploy
-deploy: ## 🚀 Deploy to k8s context defined by $KUBECTX (default: kind-rig)
+.PHONY: deploy-operator
+deploy-operator: ## 🚀 Deploy operator to k8s context defined by $KUBECTX (default: kind-rig)
 	$(HELM) upgrade --install rig-operator ./deploy/charts/rig-operator \
 			--namespace rig-system \
 			--set image.tag=$(TAG) \
@@ -103,15 +103,20 @@ deploy: ## 🚀 Deploy to k8s context defined by $KUBECTX (default: kind-rig)
 
 PLATFORM_TAG ?= latest
 
-deploy-platform: ## 🚀 Deploy to platform to k8s defined by $KUBECTX (default: kind-rig)
+.PHONY: deploy-platform
+deploy-platform: ## 🚀 Deploy platform to k8s context defined by $KUBECTX (default: kind-rig)
+	$(HELM) dependency build ./deploy/charts/rig-platform
 	$(HELM) upgrade --install rig-platform ./deploy/charts/rig-platform \
-			--namespace rig-system 																		\
-			--set postgres.enabled=true																\
-			--set image.tag=$(PLATFORM_TAG)   																	\
-			--set rig.cluster.dev_registry.enabled=true 							\
-			--set rig.cluster.dev_registry.host=localhost:30000 			\
+			--namespace rig-system \
+			--set postgres.enabled=true	\
+			--set image.tag=$(PLATFORM_TAG) \
+			--set rig.cluster.dev_registry.enabled=true \
+			--set rig.cluster.dev_registry.host=localhost:30000 \
 			--set rig.cluster.dev_registry.cluster_host=registry:5000 \
+			--set rig-operator.enabled=false \
 			--create-namespace
+
+PLATFORM_TAG ?= latest
 
 .PHONY: kind-create
 kind-create: kind ## 🐋 Create kind cluster with rig dependencies


### PR DESCRIPTION
As the rig-operator by default gets installed from the rig-platform
chart, make kind-deploy failed if the operator was already installed
as a standalone release.

This ensures that the two are installed as separate releases so that the
make targets work across the rig and the platform repositories.
