### PR TITLE
➖ Remove rig-operator as a dependency of rig-platform

### DIFF
--- a/cmd/rig/cmd/dev/kind/create.go
+++ b/cmd/rig/cmd/dev/kind/create.go
@@ -99,7 +99,6 @@ func (c Cmd) deploy(cmd *cobra.Command, args []string) error {
 			"--set", "rig.cluster.dev_registry.host=localhost:30000",
 			"--set", "rig.cluster.dev_registry.cluster_host=registry:5000",
 			"--set", "loadBalancer.enabled=true",
-			"--set", "rig-operator.enabled=false",
 		},
 	}); err != nil {
 		return err

--- a/deploy/charts/rig-platform/Chart.yaml
+++ b/deploy/charts/rig-platform/Chart.yaml
@@ -16,16 +16,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "0.2.0"
-
-dependencies:
-  - name: rig-operator
-    version: 0.1.4
-    repository: https://charts.rig.dev
-    condition: rig-operator.enabled

--- a/deploy/charts/rig-platform/templates/NOTES.txt
+++ b/deploy/charts/rig-platform/templates/NOTES.txt
@@ -1,22 +1,16 @@
-1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
-  {{- end }}
+Rig installed and can be accessed by
+
+{{- if .Values.ingress.host }}
+Public URL:
+  visit https://{{ .Values.ingress.host}}
 {{- end }}
-{{- else if .Values.loadBalancer.enabled }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "rig-platform.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "rig-platform.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "rig-platform.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
+
+{{- if .Values.loadBalancer.enabled }}
+Kind:
+  visit http://localhost:4747
 {{- else }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "rig-platform.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+Port-forward:
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "rig-platform.fullname" . }} 4747
+  visit http://localhost:4747
 {{- end }}
+

--- a/deploy/charts/rig-platform/values.yaml
+++ b/deploy/charts/rig-platform/values.yaml
@@ -125,8 +125,3 @@ rig:
 
   cluster:
     type: k8s
-
-rig-operator:
-  # wether or not to install the rig-operator as part of rig-platform. If this
-  # is disabled, the rig-operator must be installed manually.
-  enabled: true


### PR DESCRIPTION
We cannot depend on the rig-operator CRDs in the rig-platform chart by
having rig-operator as a helm dependency. The chart *needs* to be
installed before the CRDs are used.

This removes the option of installing rig-operator as a part of the
rig-platform chart.

Update NOTES.txt with proper URLs.
