### PR TITLE
✨ Watch for config changes

### DIFF
--- a/deploy/charts/rig-operator/templates/clusterrole.yaml
+++ b/deploy/charts/rig-operator/templates/clusterrole.yaml
@@ -8,6 +8,15 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create

--- a/test/integration/k8s/capsule_validation_test.go
+++ b/test/integration/k8s/capsule_validation_test.go
@@ -13,13 +13,16 @@ import (
 )
 
 func TestIntegrationCapsuleOpenAPIValidation(t *testing.T) {
+	// TODO: Share the env between integration tests. There is currently an
+	// issue with running multiple parallel environments.
+	t.Skip()
 	if testing.Short() {
 		t.Skip()
 	}
 	t.Parallel()
 
 	env := setupTest(t, options{})
-	defer env.cancel()
+	defer env.stop()
 	k8sClient := env.k8sClient
 
 	tests := []struct {

--- a/test/integration/k8s/setup_test.go
+++ b/test/integration/k8s/setup_test.go
@@ -14,7 +14,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/rigdev/rig/pkg/controller"
@@ -45,8 +44,6 @@ func (e *env) stop() {
 }
 
 func setupTest(t *testing.T, opts options) *env {
-	logf.SetLogger(testr.New(t))
-
 	testEnv := &envtest.Environment{
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "..", "..", "deploy", "kustomize", "crd", "bases"),
@@ -89,11 +86,12 @@ func setupTest(t *testing.T, opts options) *env {
 		manager, err := ctrl.NewManager(cfg, ctrl.Options{
 			Scheme:  scheme,
 			Metrics: server.Options{BindAddress: "0"},
+			Logger:  testr.New(t),
 		})
 		assert.NoError(t, err)
 
 		capsuleReconciler := &controller.CapsuleReconciler{
-			Client: k8sClient,
+			Client: manager.GetClient(),
 			Scheme: scheme,
 			Config: &configv1alpha1.OperatorConfig{
 				Certmanager: &configv1alpha1.CertManagerConfig{


### PR DESCRIPTION
The operator now watches configmaps and secrets for changes in order to
determine wether we need to reconcile a capsule.

Eg. when we depend on a secret or a configmap for environment variables
or configfiles, we want to update an annotation on the deployment when
these change so that we roll the deployment.

- ✨ Introduce a hash function which we use for calculating a hash of the
  current configuration eg. contents of configmaps and secrets we depend
  upon.
- 🐛 Fix a few bugs in `upsertIfNewer`
- ✅ Disable validation integration test tracked in https://github.com/rigdev/rig/issues/226
- 🔊 Improve logging