### PR TITLE
✨ Recreate missing resources

### DIFF
--- a/pkg/controller/capsule_controller.go
+++ b/pkg/controller/capsule_controller.go
@@ -131,6 +131,11 @@ func (r *CapsuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&rigdevv1alpha1.Capsule{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&v1.Service{}).
+		Owns(&netv1.Ingress{}).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
+		Owns(&cmv1.Certificate{}).
 		Watches(
 			&v1.ConfigMap{},
 			configEventHandler,


### PR DESCRIPTION
This makes the operator watch changes to owned `Deployment`, `Service`,
`Ingress`, `HorizontalPodAutoscaler` and `Certificate` resources. This
ensures that if a resources is missing for some reason, then we recreate
it.
