### PR TITLE
✅ Use one instance of envtest across tests

### DIFF
--- a/test/integration/k8s/capsule_controller_test.go
+++ b/test/integration/k8s/capsule_controller_test.go
@@ -29,17 +29,9 @@ import (
 	"github.com/rigdev/rig/pkg/ptr"
 )
 
-func TestIntegrationCapsuleReconcilerNginx(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
-	by(t, "Setting up test env")
-
-	env := setupTest(t, options{runManager: true})
-	defer env.stop()
-	k8sClient := env.k8sClient
+func (s *K8sTestSuite) TestController() {
+	k8sClient := s.Client
+	t := s.Suite.T()
 
 	by(t, "Creating namespace")
 

--- a/test/integration/k8s/capsule_validation_test.go
+++ b/test/integration/k8s/capsule_validation_test.go
@@ -12,18 +12,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-func TestIntegrationCapsuleOpenAPIValidation(t *testing.T) {
-	// TODO: Share the env between integration tests. There is currently an
-	// issue with running multiple parallel environments.
-	t.Skip()
-	if testing.Short() {
-		t.Skip()
-	}
-	t.Parallel()
-
-	env := setupTest(t, options{})
-	defer env.stop()
-	k8sClient := env.k8sClient
+func (s *K8sTestSuite) TestCapsuleOpenAPIValidation() {
+	k8sClient := s.Client
+	t := s.Suite.T()
 
 	tests := []struct {
 		name         string


### PR DESCRIPTION
There has been issues with running multiple instances of envtest in
parallel. This changes the tests to use a single instance of envtest by
using a testify test suite and its `SetupSuite` and `TearDownSuite` to
setup and teardown envtest.

fixes #226
