### PR TITLE
✅ Ensure teardown is run even if setup fails

### DIFF
--- a/test/integration/k8s/setup_test.go
+++ b/test/integration/k8s/setup_test.go
@@ -32,6 +32,13 @@ type K8sTestSuite struct {
 }
 
 func (s *K8sTestSuite) SetupSuite() {
+	setupDone := false
+	defer func() {
+		if !setupDone {
+			s.TearDownSuite()
+		}
+	}()
+
 	t := s.Suite.T()
 
 	s.TestEnv = &envtest.Environment{
@@ -81,11 +88,16 @@ func (s *K8sTestSuite) SetupSuite() {
 	}()
 
 	s.cancel = cancel
+	setupDone = true
 }
 
 func (s *K8sTestSuite) TearDownSuite() {
-	s.cancel()
-	s.TestEnv.Stop()
+	if s.cancel != nil {
+		s.cancel()
+	}
+	if s.TestEnv != nil {
+		s.TestEnv.Stop()
+	}
 }
 
 func TestIntegrationK8s(t *testing.T) {


### PR DESCRIPTION
If setup failed we would leave orphaned background process from envtest.
This ensures that we always run teardown, also when setup fails.

This issue with teardown not being run on setup failure is tracked in
this testify issue: https://github.com/stretchr/testify/issues/1123
