### PR TITLE
✨ Support namespace scoped shared config 

### DIFF
--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -1,0 +1,106 @@
+package hash
+
+import (
+	"fmt"
+	"hash"
+	"slices"
+
+	"golang.org/x/exp/maps"
+	v1 "k8s.io/api/core/v1"
+)
+
+func Secret(h hash.Hash, s *v1.Secret) error {
+	if _, err := h.Write([]byte(s.GetName())); err != nil {
+		return fmt.Errorf("could not write to hash: %w", err)
+	}
+	return binaryData(h, s.Data)
+}
+
+func ConfigMap(h hash.Hash, cm *v1.ConfigMap) error {
+	if _, err := h.Write([]byte(cm.GetName())); err != nil {
+		return fmt.Errorf("could not write to hash: %w", err)
+	}
+	if err := stringData(h, cm.Data); err != nil {
+		return err
+	}
+	return binaryData(h, cm.BinaryData)
+}
+
+func SecretKeys(h hash.Hash, referencedKeys []string, s *v1.Secret) error {
+	if _, err := h.Write([]byte(s.GetName())); err != nil {
+		return fmt.Errorf("could not write to hash: %w", err)
+	}
+	return binaryDataKeys(h, referencedKeys, s.Data)
+}
+
+func ConfigMapKeys(h hash.Hash, referencedKeys []string, cm *v1.ConfigMap) error {
+	if _, err := h.Write([]byte(cm.GetName())); err != nil {
+		return fmt.Errorf("could not write to hash: %w", err)
+	}
+	if err := stringDataKeys(h, referencedKeys, cm.Data); err != nil {
+		return err
+	}
+	return binaryDataKeys(h, referencedKeys, cm.BinaryData)
+}
+
+func binaryDataKeys(h hash.Hash, referencedKeys []string, data map[string][]byte) error {
+	ks := slices.Clone(referencedKeys)
+	slices.Sort(ks)
+	for _, k := range ks {
+		if v, ok := data[k]; ok {
+			if _, err := h.Write([]byte(k)); err != nil {
+				return fmt.Errorf("could not write to hash: %w", err)
+			}
+			if _, err := h.Write(v); err != nil {
+				return fmt.Errorf("could not write to hash: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func stringDataKeys(h hash.Hash, referencedKeys []string, data map[string]string) error {
+	ks := slices.Clone(referencedKeys)
+	slices.Sort(ks)
+	for _, k := range ks {
+		if v, ok := data[k]; ok {
+			if _, err := h.Write([]byte(k)); err != nil {
+				return fmt.Errorf("could not write to hash: %w", err)
+			}
+			if _, err := h.Write([]byte(v)); err != nil {
+				return fmt.Errorf("could not write to hash: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func binaryData(h hash.Hash, data map[string][]byte) error {
+	ks := maps.Keys(data)
+	slices.Sort(ks)
+	for _, k := range ks {
+		v := data[k]
+		if _, err := h.Write([]byte(k)); err != nil {
+			return fmt.Errorf("could not write to hash: %w", err)
+		}
+		if _, err := h.Write(v); err != nil {
+			return fmt.Errorf("could not write to hash: %w", err)
+		}
+	}
+	return nil
+}
+
+func stringData(h hash.Hash, data map[string]string) error {
+	ks := maps.Keys(data)
+	slices.Sort(ks)
+	for _, k := range ks {
+		v := data[k]
+		if _, err := h.Write([]byte(k)); err != nil {
+			return fmt.Errorf("could not write to hash: %w", err)
+		}
+		if _, err := h.Write([]byte(v)); err != nil {
+			return fmt.Errorf("could not write to hash: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/hash/hash_test.go
+++ b/pkg/hash/hash_test.go
@@ -1,0 +1,251 @@
+package hash_test
+
+import (
+	"hash/crc32"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	righash "github.com/rigdev/rig/pkg/hash"
+)
+
+func TestSecret(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		secretName      string
+		secretData      map[string][]byte
+		expectedWritten string
+	}{
+		{
+			name:            "secret name is included in hash",
+			secretName:      "test",
+			expectedWritten: "test",
+		},
+		{
+			name: "keys are sorted",
+			secretData: map[string][]byte{
+				"c": []byte("C"),
+				"b": []byte("B"),
+				"d": []byte("D"),
+				"a": []byte("A"),
+			},
+			expectedWritten: "aAbBcCdD",
+		},
+		{
+			name:       "secret name and data are both included in hash",
+			secretName: "test",
+			secretData: map[string][]byte{
+				"a": []byte("A"),
+			},
+			expectedWritten: "testaA",
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			expectedH := crc32.NewIEEE()
+			_, err := expectedH.Write([]byte(test.expectedWritten))
+			require.NoError(t, err)
+
+			s := &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: test.secretName},
+				Data:       test.secretData,
+			}
+
+			h := crc32.NewIEEE()
+			assert.NoError(t, righash.Secret(h, s))
+			assert.Equal(t, expectedH.Sum32(), h.Sum32())
+		})
+	}
+}
+
+func TestConfigMap(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		cmName          string
+		cmBinaryData    map[string][]byte
+		cmData          map[string]string
+		expectedWritten string
+	}{
+		{
+			name:            "configmap name is included in hash",
+			cmName:          "test",
+			expectedWritten: "test",
+		},
+		{
+			name: "keys are sorted",
+			cmData: map[string]string{
+				"c": "C",
+				"b": "B",
+				"d": "D",
+				"a": "A",
+			},
+			expectedWritten: "aAbBcCdD",
+		},
+		{
+			name:            "binary data keys are sorted",
+			expectedWritten: "aAbBcCdD",
+			cmBinaryData: map[string][]byte{
+				"c": []byte("C"),
+				"b": []byte("B"),
+				"d": []byte("D"),
+				"a": []byte("A"),
+			},
+		},
+		{
+			name:   "configmap name and data and binary data all included in hash",
+			cmName: "test",
+			cmData: map[string]string{
+				"a": "A",
+			},
+			cmBinaryData: map[string][]byte{
+				"b": []byte("B"),
+			},
+			expectedWritten: "testaAbB",
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			expectedH := crc32.NewIEEE()
+			_, err := expectedH.Write([]byte(test.expectedWritten))
+			require.NoError(t, err)
+
+			cm := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: test.cmName},
+				Data:       test.cmData,
+				BinaryData: test.cmBinaryData,
+			}
+
+			h := crc32.NewIEEE()
+			assert.NoError(t, righash.ConfigMap(h, cm))
+			assert.Equal(t, expectedH.Sum32(), h.Sum32())
+		})
+	}
+}
+
+func TestSecretKeys(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		secretName      string
+		secretData      map[string][]byte
+		referencedKeys  []string
+		expectedWritten string
+	}{
+		{
+			name:            "secret name is included in hash",
+			secretName:      "test",
+			expectedWritten: "test",
+		},
+		{
+			name:           "only referenced keys are sorted",
+			referencedKeys: []string{"a", "b"},
+			secretData: map[string][]byte{
+				"c": []byte("C"),
+				"b": []byte("B"),
+				"d": []byte("D"),
+				"a": []byte("A"),
+			},
+			expectedWritten: "aAbB",
+		},
+		{
+			name:           "secret name and data are both included in hash",
+			referencedKeys: []string{"a"},
+			secretName:     "test",
+			secretData: map[string][]byte{
+				"a": []byte("A"),
+			},
+			expectedWritten: "testaA",
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			expectedH := crc32.NewIEEE()
+			_, err := expectedH.Write([]byte(test.expectedWritten))
+			require.NoError(t, err)
+
+			s := &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: test.secretName},
+				Data:       test.secretData,
+			}
+
+			h := crc32.NewIEEE()
+			assert.NoError(t, righash.SecretKeys(h, test.referencedKeys, s))
+			assert.Equal(t, expectedH.Sum32(), h.Sum32())
+		})
+	}
+}
+
+func TestConfigMapKeys(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		cmName          string
+		cmData          map[string]string
+		cmBinaryData    map[string][]byte
+		referencedKeys  []string
+		expectedWritten string
+	}{
+		{
+			name:            "secret name is included in hash",
+			cmName:          "test",
+			expectedWritten: "test",
+		},
+		{
+			name:           "only referenced keys are sorted",
+			referencedKeys: []string{"a", "b"},
+			cmBinaryData: map[string][]byte{
+				"c": []byte("C"),
+				"b": []byte("B"),
+				"d": []byte("D"),
+				"a": []byte("A"),
+			},
+			expectedWritten: "aAbB",
+		},
+		{
+			name:           "secret name and data and binary data are all included in hash",
+			referencedKeys: []string{"a", "b"},
+			cmName:         "test",
+			cmData: map[string]string{
+				"b": "B",
+			},
+			cmBinaryData: map[string][]byte{
+				"a": []byte("A"),
+			},
+			expectedWritten: "testbBaA",
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			expectedH := crc32.NewIEEE()
+			_, err := expectedH.Write([]byte(test.expectedWritten))
+			require.NoError(t, err)
+
+			cm := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: test.cmName},
+				Data:       test.cmData,
+				BinaryData: test.cmBinaryData,
+			}
+
+			h := crc32.NewIEEE()
+			assert.NoError(t, righash.ConfigMapKeys(h, test.referencedKeys, cm))
+			assert.Equal(t, expectedH.Sum32(), h.Sum32())
+		})
+	}
+}

--- a/test/integration/k8s/capsule_validation_test.go
+++ b/test/integration/k8s/capsule_validation_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	alpha1v1 "github.com/rigdev/rig/pkg/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	alpha1v1 "github.com/rigdev/rig/pkg/api/v1alpha1"
 )
 
 func (s *K8sTestSuite) TestCapsuleOpenAPIValidation() {

--- a/test/integration/k8s/suite_test.go
+++ b/test/integration/k8s/suite_test.go
@@ -16,11 +16,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	"github.com/rigdev/rig/pkg/controller"
-
 	configv1alpha1 "github.com/rigdev/rig/pkg/api/config/v1alpha1"
+	"github.com/rigdev/rig/pkg/controller"
 	"github.com/rigdev/rig/pkg/manager"
 	//+kubebuilder:scaffold:imports
+)
+
+const (
+	waitFor = time.Second * 10
+	tick    = time.Millisecond * 200
 )
 
 type K8sTestSuite struct {
@@ -107,8 +111,3 @@ func TestIntegrationK8s(t *testing.T) {
 	t.Parallel()
 	suite.Run(t, new(K8sTestSuite))
 }
-
-const (
-	waitFor = time.Second * 10
-	tick    = time.Millisecond * 200
-)


### PR DESCRIPTION
Adds a new feature where namespace scoped environment variables can
be added by annotating a secret or configmap with rig.dev/shared-config.

Introduce `pkg/hash` for calculating checksums of configmaps and
secrets.