### PR TITLE
👷 Add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,16 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-message: 'This issue is stale because it has been waiting for more information for 30 days with no activity. Remove stale label or comment or this will be closed in 7 days. If the issue has been clarified, remove the needs-more-info label.'
+          stale-pr-message: 'This pr is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          any-of-issue-labels: needs-more-info


### PR DESCRIPTION
After 30 days of inactivity we will mark stale and after 7 days the
issue or PR will be closed.

For issues, we will only check for staleness for issues with the
needs-more-info label.
