### PR TITLE
:bug: Ensure leader election uses same namespace as operator

### DIFF
--- a/deploy/charts/rig-operator/templates/deployment.yaml
+++ b/deploy/charts/rig-operator/templates/deployment.yaml
@@ -54,6 +54,11 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           resources: {{ toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           volumeMounts:
             - name: config
               readOnly: true

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1,6 +1,8 @@
 package manager
 
 import (
+	"os"
+
 	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -27,6 +29,14 @@ func NewScheme() *runtime.Scheme {
 	return s
 }
 
+func getEnvWithDefault(env, def string) string {
+	v := os.Getenv(env)
+	if v == "" {
+		return def
+	}
+	return env
+}
+
 func NewManager(cfgS config.Service, scheme *runtime.Scheme) (manager.Manager, error) {
 	cfg := cfgS.Get()
 
@@ -39,8 +49,9 @@ func NewManager(cfgS config.Service, scheme *runtime.Scheme) (manager.Manager, e
 		Logger:                  logger,
 		LeaderElection:          *cfg.LeaderElectionEnabled,
 		LeaderElectionID:        "3d9f417a.rig.dev",
-		LeaderElectionNamespace: "rig-system",
+		LeaderElectionNamespace: getEnvWithDefault("POD_NAMESPACE", "rig-system"),
 	})
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Leader election namespace was hardcoded to "rig-system". When deploying
in other namespaces the granted role didnt allow for access to leases in
rig-system but instead in the namespace where it was deployed.

This change uses the downward API to make an environment variable
available in the pod for what namespace we are running in. This can then
be used to ensure that we use lease resources in the same namespace as
where the operator is running.

fixes #267 