### PR TITLE
:bug: Ensure configmap and secret volume names dont overlap

### DIFF
--- a/pkg/controller/capsule_controller.go
+++ b/pkg/controller/capsule_controller.go
@@ -610,7 +610,7 @@ func createDeployment(
 		var name string
 		switch {
 		case f.ConfigMap != nil:
-			name = "volume-" + strings.ReplaceAll(f.ConfigMap.Name, ".", "-")
+			name = "configmap-" + strings.ReplaceAll(f.ConfigMap.Name, ".", "-")
 			volumes = append(volumes, v1.Volume{
 				Name: name,
 				VolumeSource: v1.VolumeSource{
@@ -628,7 +628,7 @@ func createDeployment(
 				},
 			})
 		case f.Secret != nil:
-			name = "volume-" + strings.ReplaceAll(f.Secret.Name, ".", "-")
+			name = "secret-" + strings.ReplaceAll(f.Secret.Name, ".", "-")
 			volumes = append(volumes, v1.Volume{
 				Name: name,
 				VolumeSource: v1.VolumeSource{


### PR DESCRIPTION
If a Capsule references a Secret *and* a ConfigMap sharing the same
name, we are generating a deployment with name clashes in the list of
volumes.

This fixes the generated volume names, by changing their prefix to be
either configmap or secret instead of volume.
