### PR TITLE
:building_construction: CLI: Reintroduce FX as a step strictly after Cobra command parsing

### DIFF
--- a/cmd/rig/cmd/auth/get.go
+++ b/cmd/rig/cmd/auth/get.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"time"
 
 	"github.com/bufbuild/connect-go"
@@ -10,8 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) get(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error {
 	res, err := c.Rig.Authentication().Get(ctx, &connect.Request[authentication.GetRequest]{
 		Msg: &authentication.GetRequest{},
 	})

--- a/cmd/rig/cmd/auth/login.go
+++ b/cmd/rig/cmd/auth/login.go
@@ -14,8 +14,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) login(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) login(ctx context.Context, cmd *cobra.Command, args []string) error {
 	res, err := c.loginWithRetry(ctx, authUserIdentifier, authPassword, auth.RigProjectID)
 	if err != nil {
 		return err

--- a/cmd/rig/cmd/auth/setup.go
+++ b/cmd/rig/cmd/auth/setup.go
@@ -26,7 +26,7 @@ type Cmd struct {
 	Cfg *cmd_config.Config
 }
 
-func (c Cmd) Setup(parent *cobra.Command) {
+func Setup(parent *cobra.Command) {
 	auth := &cobra.Command{
 		Use:   "auth",
 		Short: "Manage authentication for the current user",
@@ -41,7 +41,7 @@ func (c Cmd) Setup(parent *cobra.Command) {
 			base.OmitProject: "",
 		},
 		ValidArgsFunction: common.NoCompletions,
-		RunE:              c.login,
+		RunE:              base.Register(func(c Cmd) any { return c.login }),
 	}
 	login.Flags().StringVarP(&authUserIdentifier, "user", "u", "", "useridentifier [username | email | phone number]")
 	login.Flags().StringVarP(&authPassword, "password", "p", "", "password of the user")
@@ -53,7 +53,7 @@ func (c Cmd) Setup(parent *cobra.Command) {
 		Use:   "get",
 		Short: "Get user information associated with the current user",
 		Args:  cobra.NoArgs,
-		RunE:  c.get,
+		RunE:  base.Register(func(c Cmd) any { return c.get }),
 		Annotations: map[string]string{
 			base.OmitProject: "",
 		},

--- a/cmd/rig/cmd/base/auth.go
+++ b/cmd/rig/cmd/base/auth.go
@@ -23,12 +23,11 @@ var (
 	OmitProject = "OMIT_PROJECT"
 )
 
-func CheckAuth(cmd *cobra.Command, rc rig.Client, cfg *cmd_config.Config) error {
-	if cmd.Parent().Use == "completion" {
+func CheckAuth(ctx context.Context, cmd *cobra.Command, rc rig.Client, cfg *cmd_config.Config) error {
+	if cmd.HasParent() && cmd.Parent().Use == "completion" {
 		return nil
 	}
 
-	ctx := context.Background()
 	if _, ok := cmd.Annotations[OmitUser]; !ok {
 		if err := authUser(ctx, rc, cfg); err != nil {
 			return err

--- a/cmd/rig/cmd/base/common.go
+++ b/cmd/rig/cmd/base/common.go
@@ -1,6 +1,30 @@
 package base
 
+import "github.com/spf13/cobra"
+
 const (
 	RFC3339NanoFixed  = "2006-01-02T15:04:05.000000000Z07:00"
 	RFC3339MilliFixed = "2006-01-02T15:04:05.000Z07:00"
 )
+
+// ExecutePersistentPreRunERecursively executes any registrered PersistentPreRunE functions
+// on the parent-chain from the given cmd.
+// The 'persistent' in PersistentPreRunE is only if no child-commands also sets the function.
+func ExecutePersistentPreRunERecursively(cmd *cobra.Command, args []string) error {
+	if !cmd.HasParent() {
+		return nil
+	}
+	cmd = cmd.Parent()
+
+	if err := ExecutePersistentPreRunERecursively(cmd, args); err != nil {
+		return err
+	}
+
+	if cmd.PersistentPreRunE != nil {
+		if err := cmd.PersistentPreRunE(cmd, args); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/rig/cmd/base/register.go
+++ b/cmd/rig/cmd/base/register.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/docker/client"
 	"github.com/rigdev/rig/cmd/rig/cmd/cmd_config"
+	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 )
@@ -64,4 +65,70 @@ func getContext(cfg *cmd_config.Config) (*cmd_config.Context, error) {
 	}
 
 	return c, nil
+}
+
+// Register solves an annoying problem I haven't found a good solution to yet.
+// 1. We want to use FX to generate all the dependencies for the commands
+//
+// 2. We only want to generate dependencies strictly for the commands currently in the
+// command chain being executed. Some dependencies prompt the user interactively if their
+// values don't already exist (e.g. some Config and Context does this). We don't want this
+// to happen for all commands  (otherwise it would prompt during e.g. 'help' which is super weird behaviour).
+//
+// 3. We would like to encapsulate all dependencies to a command in a struct (called Cmd structs here)
+// to make it possible to easily call helper functions with the dependencies as well and not have
+// unwieldy function signatures.
+//
+// 4. Cobra has no lifecycle step in between parsing all commands and starting executing the functions
+// defined on the cobra.Commands (e.g. PreRun, Run...)
+//
+// Conclusion: We need to have a reference to all functions being called before any cobra parsing happens
+// These functions are instance methods on objects we cannot construct before any Cobra parsing happens
+// :(
+func Register[T any](f func(T) any) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		return fx.New(
+			Module,
+			fx.NopLogger,
+			fx.Provide(func() *cobra.Command { return cmd }),
+			fx.Provide(func() []string { return args }),
+			fx.Invoke(func(t T, ctx context.Context, cmd *cobra.Command, args []string) error {
+				switch f := f(t).(type) {
+				case func(context.Context, *cobra.Command, []string) error:
+					return f(ctx, cmd, args)
+				case func(*cobra.Command, []string) error:
+					return f(cmd, args)
+				default:
+					return fmt.Errorf("unexpected function signature %T to Register", f)
+				}
+			}),
+		).Err()
+	}
+}
+
+// See Register
+func RegisterCompletion[T any](f func(T) any) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		var completions []string
+		var directive cobra.ShellCompDirective
+		if err := fx.New(
+			Module,
+			fx.NopLogger,
+			fx.Provide(func() *cobra.Command { return cmd }),
+			fx.Provide(func() []string { return args }),
+			fx.Invoke(func(t T, ctx context.Context, cmd *cobra.Command, args []string) error {
+				switch f := f(t).(type) {
+				case func(*cobra.Command, []string, string) error:
+					return f(cmd, args, toComplete)
+				case func(context.Context, *cobra.Command, []string, string) error:
+					return f(ctx, cmd, args, toComplete)
+				default:
+					return fmt.Errorf("unexpected function signature %T to Register", f)
+				}
+			}),
+		).Err(); err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+		return completions, directive
+	}
 }

--- a/cmd/rig/cmd/capsule/builddeploy/create_build.go
+++ b/cmd/rig/cmd/capsule/builddeploy/create_build.go
@@ -1,6 +1,8 @@
 package builddeploy
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/capsule"
 	capsule_cmd "github.com/rigdev/rig/cmd/rig/cmd/capsule"
@@ -8,9 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) createBuild(cmd *cobra.Command, args []string) error {
+func (c Cmd) createBuild(ctx context.Context, cmd *cobra.Command, args []string) error {
 	var err error
-	ctx := c.Ctx
 
 	imageRef := imageRefFromFlags()
 	if image == "" {

--- a/cmd/rig/cmd/capsule/builddeploy/deploy.go
+++ b/cmd/rig/cmd/capsule/builddeploy/deploy.go
@@ -25,8 +25,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) deploy(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) deploy(ctx context.Context, cmd *cobra.Command, args []string) error {
 	buildID, err := c.getBuildID(ctx, capsule_cmd.CapsuleID)
 	if err != nil {
 		return err

--- a/cmd/rig/cmd/capsule/builddeploy/get_build.go
+++ b/cmd/rig/cmd/capsule/builddeploy/get_build.go
@@ -1,6 +1,7 @@
 package builddeploy
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -13,8 +14,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) getBuild(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) getBuild(ctx context.Context, cmd *cobra.Command, args []string) error {
 	resp, err := c.Rig.Capsule().ListBuilds(ctx, &connect.Request[capsule.ListBuildsRequest]{
 		Msg: &capsule.ListBuildsRequest{
 			CapsuleId: capsule_cmd.CapsuleID,

--- a/cmd/rig/cmd/capsule/env/get.go
+++ b/cmd/rig/cmd/capsule/env/get.go
@@ -1,12 +1,13 @@
 package env
 
 import (
+	"context"
+
 	"github.com/rigdev/rig/cmd/rig/cmd/capsule"
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) get(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error {
 	r, err := capsule.GetCurrentRollout(ctx, c.Rig)
 	if err != nil {
 		return err

--- a/cmd/rig/cmd/capsule/env/remove.go
+++ b/cmd/rig/cmd/capsule/env/remove.go
@@ -1,6 +1,8 @@
 package env
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/capsule"
 	"github.com/rigdev/rig/cmd/common"
@@ -9,8 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) remove(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) remove(ctx context.Context, cmd *cobra.Command, args []string) error {
 	var key string
 	var err error
 	if len(args) > 0 {

--- a/cmd/rig/cmd/capsule/env/set.go
+++ b/cmd/rig/cmd/capsule/env/set.go
@@ -1,6 +1,8 @@
 package env
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/capsule"
 	capsule_cmd "github.com/rigdev/rig/cmd/rig/cmd/capsule"
@@ -8,8 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) set(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) set(ctx context.Context, cmd *cobra.Command, args []string) error {
 	if len(args) != 2 {
 		return errors.InvalidArgumentErrorf("expected key and value arguments")
 	}

--- a/cmd/rig/cmd/capsule/instance/exec.go
+++ b/cmd/rig/cmd/capsule/instance/exec.go
@@ -1,6 +1,7 @@
 package instance
 
 import (
+	"context"
 	"errors"
 	"io"
 	"strings"
@@ -35,8 +36,7 @@ func listen(stream *connect.BidiStreamForClient[capsule.ExecuteRequest, capsule.
 	return doneChan
 }
 
-func (c Cmd) exec(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) exec(ctx context.Context, cmd *cobra.Command, args []string) error {
 	arg := ""
 	if len(args) > 0 {
 		arg = args[0]

--- a/cmd/rig/cmd/capsule/instance/get.go
+++ b/cmd/rig/cmd/capsule/instance/get.go
@@ -1,6 +1,7 @@
 package instance
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -14,9 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) get(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
-
+func (c Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error {
 	// TODO Fix to use the new dataformat
 	resp, err := c.Rig.Capsule().ListInstanceStatuses(ctx, connect.NewRequest(&capsule.ListInstanceStatusesRequest{
 		CapsuleId: cmd_capsule.CapsuleID,

--- a/cmd/rig/cmd/capsule/instance/logs.go
+++ b/cmd/rig/cmd/capsule/instance/logs.go
@@ -1,6 +1,7 @@
 package instance
 
 import (
+	"context"
 	"time"
 
 	"github.com/bufbuild/connect-go"
@@ -10,8 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-func (c Cmd) logs(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) logs(ctx context.Context, cmd *cobra.Command, args []string) error {
 	arg := ""
 	if len(args) > 0 {
 		arg = args[0]

--- a/cmd/rig/cmd/capsule/instance/restart.go
+++ b/cmd/rig/cmd/capsule/instance/restart.go
@@ -1,14 +1,15 @@
 package instance
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/capsule"
 	capsule_cmd "github.com/rigdev/rig/cmd/rig/cmd/capsule"
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) restart(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) restart(ctx context.Context, cmd *cobra.Command, args []string) error {
 	arg := ""
 	if len(args) > 0 {
 		arg = args[0]

--- a/cmd/rig/cmd/capsule/mount/get.go
+++ b/cmd/rig/cmd/capsule/mount/get.go
@@ -13,8 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) get(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error {
 	r, err := capsule_cmd.GetCurrentRollout(ctx, c.Rig)
 	if err != nil {
 		return err

--- a/cmd/rig/cmd/capsule/mount/remove.go
+++ b/cmd/rig/cmd/capsule/mount/remove.go
@@ -1,6 +1,8 @@
 package mount
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/capsule"
 	"github.com/rigdev/rig/cmd/common"
@@ -9,8 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) remove(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) remove(ctx context.Context, cmd *cobra.Command, args []string) error {
 	var path string
 	var err error
 	if len(args) != 1 {

--- a/cmd/rig/cmd/capsule/mount/set.go
+++ b/cmd/rig/cmd/capsule/mount/set.go
@@ -1,6 +1,7 @@
 package mount
 
 import (
+	"context"
 	"os"
 
 	"github.com/bufbuild/connect-go"
@@ -11,8 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) set(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) set(ctx context.Context, cmd *cobra.Command, args []string) error {
 	var err error
 	if srcPath == "" {
 		srcPath, err = common.PromptInput("Source path", common.ValidateFilePathOpt)

--- a/cmd/rig/cmd/capsule/network/configure.go
+++ b/cmd/rig/cmd/capsule/network/configure.go
@@ -20,8 +20,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func (c Cmd) configure(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) configure(ctx context.Context, cmd *cobra.Command, args []string) error {
 	var err error
 	networkFile := ""
 	if len(args) == 0 {

--- a/cmd/rig/cmd/capsule/network/get.go
+++ b/cmd/rig/cmd/capsule/network/get.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -11,8 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) get(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error {
 	n, err := capsule_cmd.GetCurrentNetwork(ctx, c.Rig)
 	if err != nil {
 		return err

--- a/cmd/rig/cmd/capsule/rollout/events.go
+++ b/cmd/rig/cmd/capsule/rollout/events.go
@@ -1,6 +1,7 @@
 package rollout
 
 import (
+	"context"
 	"strconv"
 	"time"
 
@@ -13,8 +14,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) capsuleEvents(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) capsuleEvents(ctx context.Context, cmd *cobra.Command, args []string) error {
 	var rollout uint64
 	var err error
 	if len(args) > 0 {

--- a/cmd/rig/cmd/capsule/rollout/get.go
+++ b/cmd/rig/cmd/capsule/rollout/get.go
@@ -1,6 +1,7 @@
 package rollout
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -16,8 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) get(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error {
 	resp, err := c.Rig.Capsule().ListRollouts(ctx, &connect.Request[capsule.ListRolloutsRequest]{
 		Msg: &capsule.ListRolloutsRequest{
 			CapsuleId: capsule_cmd.CapsuleID,

--- a/cmd/rig/cmd/capsule/rollout/rollback.go
+++ b/cmd/rig/cmd/capsule/rollout/rollback.go
@@ -13,8 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) rollback(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) rollback(ctx context.Context, cmd *cobra.Command, args []string) error {
 	rolloutID, err := c.getRollback(ctx)
 	if err != nil {
 		return err

--- a/cmd/rig/cmd/capsule/root/abort.go
+++ b/cmd/rig/cmd/capsule/root/abort.go
@@ -1,14 +1,15 @@
 package root
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/capsule"
 	capsule_cmd "github.com/rigdev/rig/cmd/rig/cmd/capsule"
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) abort(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) abort(ctx context.Context, cmd *cobra.Command, args []string) error {
 	cc, err := c.Rig.Capsule().Get(ctx, &connect.Request[capsule.GetRequest]{
 		Msg: &capsule.GetRequest{
 			CapsuleId: capsule_cmd.CapsuleID,

--- a/cmd/rig/cmd/capsule/root/config.go
+++ b/cmd/rig/cmd/capsule/root/config.go
@@ -1,6 +1,8 @@
 package root
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/capsule"
 	capsule_cmd "github.com/rigdev/rig/cmd/rig/cmd/capsule"
@@ -8,8 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) config(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) config(ctx context.Context, cmd *cobra.Command, args []string) error {
 	if len(args) > 0 && command == "" {
 		return errors.InvalidArgumentErrorf("command must be set when args are provided")
 	}

--- a/cmd/rig/cmd/capsule/root/create.go
+++ b/cmd/rig/cmd/capsule/root/create.go
@@ -1,6 +1,7 @@
 package root
 
 import (
+	"context"
 	"os"
 	"strconv"
 
@@ -12,8 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c *Cmd) create(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c *Cmd) create(ctx context.Context, cmd *cobra.Command, args []string) error {
 	var err error
 	if capsule_cmd.CapsuleID == "" {
 		capsule_cmd.CapsuleID, err = common.PromptInput("Capsule name:", common.ValidateSystemNameOpt)

--- a/cmd/rig/cmd/capsule/root/delete.go
+++ b/cmd/rig/cmd/capsule/root/delete.go
@@ -1,14 +1,15 @@
 package root
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/capsule"
 	capsule_cmd "github.com/rigdev/rig/cmd/rig/cmd/capsule"
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) delete(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) delete(ctx context.Context, cmd *cobra.Command, args []string) error {
 	if _, err := c.Rig.Capsule().Delete(ctx, &connect.Request[capsule.DeleteRequest]{
 		Msg: &capsule.DeleteRequest{
 			CapsuleId: capsule_cmd.CapsuleID,

--- a/cmd/rig/cmd/capsule/root/get.go
+++ b/cmd/rig/cmd/capsule/root/get.go
@@ -1,6 +1,7 @@
 package root
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/bufbuild/connect-go"
@@ -13,8 +14,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) get(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error {
 	resp, err := c.Rig.Capsule().List(ctx, &connect.Request[capsule.ListRequest]{
 		Msg: &capsule.ListRequest{
 			Pagination: &model.Pagination{

--- a/cmd/rig/cmd/capsule/root/logs.go
+++ b/cmd/rig/cmd/capsule/root/logs.go
@@ -1,6 +1,7 @@
 package root
 
 import (
+	"context"
 	"time"
 
 	"github.com/bufbuild/connect-go"
@@ -10,9 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-func (c Cmd) logs(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
-
+func (c Cmd) logs(ctx context.Context, cmd *cobra.Command, args []string) error {
 	duration, err := time.ParseDuration(since)
 	if err != nil {
 		return err

--- a/cmd/rig/cmd/capsule/scale/get.go
+++ b/cmd/rig/cmd/capsule/scale/get.go
@@ -1,6 +1,7 @@
 package scale
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -9,8 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (r Cmd) get(cmd *cobra.Command, args []string) error {
-	ctx := r.Ctx
+func (r Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error {
 	rollout, err := capsule.GetCurrentRollout(ctx, r.Rig)
 	if err != nil {
 		return err

--- a/cmd/rig/cmd/capsule/scale/horizontal.go
+++ b/cmd/rig/cmd/capsule/scale/horizontal.go
@@ -1,6 +1,8 @@
 package scale
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/capsule"
 	capsule_cmd "github.com/rigdev/rig/cmd/rig/cmd/capsule"
@@ -8,8 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) horizontal(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) horizontal(ctx context.Context, cmd *cobra.Command, args []string) error {
 	rollout, err := capsule_cmd.GetCurrentRollout(ctx, c.Rig)
 	if err != nil {
 		return nil
@@ -58,8 +59,7 @@ func (c Cmd) horizontal(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (c Cmd) autoscale(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) autoscale(ctx context.Context, cmd *cobra.Command, args []string) error {
 	rollout, err := capsule_cmd.GetCurrentRollout(ctx, c.Rig)
 	if err != nil {
 		return nil

--- a/cmd/rig/cmd/capsule/scale/setup.go
+++ b/cmd/rig/cmd/capsule/scale/setup.go
@@ -1,10 +1,9 @@
 package scale
 
 import (
-	"context"
-
 	"github.com/rigdev/rig-go-sdk"
 	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 )
@@ -35,11 +34,10 @@ var (
 type Cmd struct {
 	fx.In
 
-	Ctx context.Context
 	Rig rig.Client
 }
 
-func (r Cmd) Setup(parent *cobra.Command) {
+func Setup(parent *cobra.Command) {
 	scale := &cobra.Command{
 		Use:   "scale",
 		Short: "Scale and inspect the resources of the capsule",
@@ -49,7 +47,7 @@ func (r Cmd) Setup(parent *cobra.Command) {
 		Use:               "get",
 		Short:             "Displays the resources (container size) and replicas of the capsule",
 		Args:              cobra.NoArgs,
-		RunE:              r.get,
+		RunE:              base.Register(func(c Cmd) any { return c.get }),
 		ValidArgsFunction: common.NoCompletions,
 	}
 	scaleGet.Flags().BoolVar(&outputJSON, "json", false, "output as json")
@@ -60,7 +58,7 @@ func (r Cmd) Setup(parent *cobra.Command) {
 		Use:               "vertical",
 		Short:             "Vertically scaling the capsule (setting the container size)",
 		Args:              cobra.NoArgs,
-		RunE:              r.vertical,
+		RunE:              base.Register(func(c Cmd) any { return c.vertical }),
 		ValidArgsFunction: common.NoCompletions,
 	}
 	scaleVertical.Flags().StringVar(&requestCPU, "request-cpu", "", "Minimum CPU cores per container")
@@ -87,7 +85,7 @@ func (r Cmd) Setup(parent *cobra.Command) {
 		Use:               "horizontal",
 		Short:             "Horizontally scaling the capsule (setting the number of replicas and configuring the autoscaler)",
 		Args:              cobra.NoArgs,
-		RunE:              r.horizontal,
+		RunE:              base.Register(func(c Cmd) any { return c.horizontal }),
 		ValidArgsFunction: common.NoCompletions,
 	}
 	scaleHorizontal.Flags().Uint32VarP(&replicas, "replicas", "r", 0, "number of replicas to scale to")
@@ -102,7 +100,7 @@ func (r Cmd) Setup(parent *cobra.Command) {
 		Use:               "autoscale",
 		Short:             "Configure the autoscaler for horizontal scaling",
 		Args:              cobra.NoArgs,
-		RunE:              r.autoscale,
+		RunE:              base.Register(func(c Cmd) any { return c.autoscale }),
 		ValidArgsFunction: common.NoCompletions,
 	}
 	scaleHorizontalAuto.Flags().Uint32VarP(&utilizationPercentage, "utilization-percentage", "u", 0, "CPU utilization percentage for the autoscaler. 1 <= 100")

--- a/cmd/rig/cmd/capsule/scale/vertical.go
+++ b/cmd/rig/cmd/capsule/scale/vertical.go
@@ -1,6 +1,7 @@
 package scale
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strconv"
@@ -14,8 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func (r Cmd) vertical(cmd *cobra.Command, args []string) error {
-	ctx := r.Ctx
+func (r Cmd) vertical(ctx context.Context, cmd *cobra.Command, args []string) error {
 	container, _, err := capsule_cmd.GetCurrentContainerResources(ctx, r.Rig)
 	if err != nil {
 		return nil

--- a/cmd/rig/cmd/cluster/getconfig.go
+++ b/cmd/rig/cmd/cluster/getconfig.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/bufbuild/connect-go"
@@ -9,8 +10,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func (c Cmd) get(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error {
 	resp, err := c.Rig.Cluster().GetConfig(ctx, connect.NewRequest(&cluster.GetConfigRequest{}))
 	if err != nil {
 		return err

--- a/cmd/rig/cmd/cluster/setup.go
+++ b/cmd/rig/cmd/cluster/setup.go
@@ -1,10 +1,9 @@
 package cluster
 
 import (
-	"context"
-
 	"github.com/rigdev/rig-go-sdk"
 	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 )
@@ -12,11 +11,10 @@ import (
 type Cmd struct {
 	fx.In
 
-	Ctx context.Context
 	Rig rig.Client
 }
 
-func (c Cmd) Setup(parent *cobra.Command) {
+func Setup(parent *cobra.Command) {
 	cluster := &cobra.Command{
 		Use:   "cluster",
 		Short: "Manage Rig clusters",
@@ -26,7 +24,7 @@ func (c Cmd) Setup(parent *cobra.Command) {
 		Use:               "get-config",
 		Short:             "Returns the config of the Rig cluster",
 		Args:              cobra.NoArgs,
-		RunE:              c.get,
+		RunE:              base.Register(func(c Cmd) any { return c.get }),
 		ValidArgsFunction: common.NoCompletions,
 	}
 

--- a/cmd/rig/cmd/config/setup.go
+++ b/cmd/rig/cmd/config/setup.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"context"
 	"strings"
 
 	"github.com/rigdev/rig-go-sdk"
@@ -15,12 +14,11 @@ import (
 type Cmd struct {
 	fx.In
 
-	Ctx context.Context
 	Rig rig.Client
 	Cfg *cmd_config.Config
 }
 
-func (c Cmd) Setup(parent *cobra.Command) {
+func Setup(parent *cobra.Command) {
 	config := &cobra.Command{
 		Use:   "config",
 		Short: "Manage Rig CLI configuration",
@@ -30,7 +28,7 @@ func (c Cmd) Setup(parent *cobra.Command) {
 		Use:   "init",
 		Short: "Initialize a new context",
 		Args:  cobra.NoArgs,
-		RunE:  c.init,
+		RunE:  base.Register(func(c Cmd) any { return c.init }),
 		Annotations: map[string]string{
 			base.OmitProject: "",
 			base.OmitUser:    "",
@@ -43,12 +41,15 @@ func (c Cmd) Setup(parent *cobra.Command) {
 		Use:   "use-context [context]",
 		Short: "Change the current context to use",
 		Args:  cobra.MaximumNArgs(1),
-		RunE:  c.useContext,
+		RunE:  base.Register(func(c Cmd) any { return c.useContext }),
 		Annotations: map[string]string{
 			base.OmitProject: "",
 			base.OmitUser:    "",
 		},
-		ValidArgsFunction: common.Complete(c.completions, common.MaxArgsCompletionFilter(1)),
+		ValidArgsFunction: common.Complete(
+			base.RegisterCompletion(func(c Cmd) any { return c.completions }),
+			common.MaxArgsCompletionFilter(1),
+		),
 	}
 	config.AddCommand(useContext)
 

--- a/cmd/rig/cmd/dev/docker/create.go
+++ b/cmd/rig/cmd/dev/docker/create.go
@@ -22,9 +22,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) create(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
-
+func (c Cmd) create(ctx context.Context, cmd *cobra.Command, args []string) error {
 	v, err := c.DockerClient.VolumeCreate(ctx, volume.CreateOptions{
 		Name: "rig-platform-postgres-data",
 	})

--- a/cmd/rig/cmd/dev/docker/setup.go
+++ b/cmd/rig/cmd/dev/docker/setup.go
@@ -22,7 +22,7 @@ type Cmd struct {
 	Cfg          *cmd_config.Config
 }
 
-func (c *Cmd) Setup(parent *cobra.Command) {
+func Setup(parent *cobra.Command) {
 	docker := &cobra.Command{
 		Use:   "docker",
 		Short: "The docker command is used to setup and manage a development Docker cluster running Rig",
@@ -32,7 +32,7 @@ func (c *Cmd) Setup(parent *cobra.Command) {
 		Use:   "create",
 		Short: "Create a Rig cluster in Docker for local development",
 		Args:  cobra.NoArgs,
-		RunE:  c.create,
+		RunE:  base.Register(func(c Cmd) any { return c.create }),
 		Annotations: map[string]string{
 			base.OmitUser:    "",
 			base.OmitProject: "",

--- a/cmd/rig/cmd/dev/kind/create.go
+++ b/cmd/rig/cmd/dev/kind/create.go
@@ -25,7 +25,7 @@ var config string
 //go:embed registry.yaml
 var registry string
 
-func (c Cmd) create(cmd *cobra.Command, args []string) error {
+func (c Cmd) create(ctx context.Context, cmd *cobra.Command, args []string) error {
 	if err := checkBinaries(kubectl, kind, helm); err != nil {
 		return err
 	}
@@ -42,7 +42,7 @@ func (c Cmd) create(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := c.deploy(cmd, args); err != nil {
+	if err := c.deploy(ctx, cmd, args); err != nil {
 		return err
 	}
 
@@ -72,8 +72,7 @@ func (c Cmd) create(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (c Cmd) deploy(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) deploy(ctx context.Context, cmd *cobra.Command, args []string) error {
 	if err := checkBinaries(kind, kubectl, helm, docker); err != nil {
 		return err
 	}
@@ -230,7 +229,7 @@ func (c Cmd) loadImage(ctx context.Context, image, tag string) error {
 	return nil
 }
 
-func (c Cmd) clean(cmd *cobra.Command, args []string) error {
+func (c Cmd) clean(ctx context.Context, cmd *cobra.Command, args []string) error {
 	if err := checkBinaries(kind); err != nil {
 		return err
 	}

--- a/cmd/rig/cmd/dev/kind/setup.go
+++ b/cmd/rig/cmd/dev/kind/setup.go
@@ -1,8 +1,6 @@
 package kind
 
 import (
-	"context"
-
 	"github.com/docker/docker/client"
 	"github.com/rigdev/rig-go-sdk"
 	"github.com/rigdev/rig/cmd/common"
@@ -22,13 +20,12 @@ var (
 type Cmd struct {
 	fx.In
 
-	Ctx          context.Context
 	DockerClient *client.Client
 	Rig          rig.Client
 	Cfg          *cmd_config.Config
 }
 
-func (c *Cmd) Setup(parent *cobra.Command) {
+func Setup(parent *cobra.Command) {
 	kind := &cobra.Command{
 		Use:   "kind",
 		Short: "The kind command is used to setup and manage a development kubernetes cluster running Rig using Kind",
@@ -38,7 +35,7 @@ func (c *Cmd) Setup(parent *cobra.Command) {
 		Use:   "create",
 		Short: "Create a rig cluster in Kind for local development",
 		Args:  cobra.NoArgs,
-		RunE:  c.create,
+		RunE:  base.Register(func(c Cmd) any { return c.create }),
 		Annotations: map[string]string{
 			base.OmitUser:    "",
 			base.OmitProject: "",
@@ -59,7 +56,7 @@ func (c *Cmd) Setup(parent *cobra.Command) {
 		Use:   "deploy",
 		Short: "Deploy a new (or specific) version of Rig to the kind cluster",
 		Args:  cobra.NoArgs,
-		RunE:  c.deploy,
+		RunE:  base.Register(func(c Cmd) any { return c.deploy }),
 		Annotations: map[string]string{
 			base.OmitUser:    "",
 			base.OmitProject: "",
@@ -80,7 +77,7 @@ func (c *Cmd) Setup(parent *cobra.Command) {
 		Use:   "clean",
 		Short: "Deletes the rig kind-cluster",
 		Args:  cobra.NoArgs,
-		RunE:  c.clean,
+		RunE:  base.Register(func(c Cmd) any { return c.clean }),
 		Annotations: map[string]string{
 			base.OmitUser:    "",
 			base.OmitProject: "",

--- a/cmd/rig/cmd/dev/setup.go
+++ b/cmd/rig/cmd/dev/setup.go
@@ -4,24 +4,16 @@ import (
 	"github.com/rigdev/rig/cmd/rig/cmd/dev/docker"
 	"github.com/rigdev/rig/cmd/rig/cmd/dev/kind"
 	"github.com/spf13/cobra"
-	"go.uber.org/fx"
 )
 
-type Cmd struct {
-	fx.In
-
-	Kind   kind.Cmd
-	Docker docker.Cmd
-}
-
-func (d *Cmd) Setup(parent *cobra.Command) {
+func Setup(parent *cobra.Command) {
 	dev := &cobra.Command{
 		Use:   "dev",
 		Short: "Setup and manage development environments",
 	}
 
-	d.Kind.Setup(dev)
-	d.Docker.Setup(dev)
+	kind.Setup(dev)
+	docker.Setup(dev)
 
 	parent.AddCommand(dev)
 }

--- a/cmd/rig/cmd/group/create.go
+++ b/cmd/rig/cmd/group/create.go
@@ -1,14 +1,15 @@
 package group
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/group"
 	"github.com/rigdev/rig/cmd/common"
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) create(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) create(ctx context.Context, cmd *cobra.Command, args []string) error {
 	var err error
 	if name == "" {
 		name, err = common.PromptInput("Name:", common.ValidateNonEmptyOpt)

--- a/cmd/rig/cmd/group/delete.go
+++ b/cmd/rig/cmd/group/delete.go
@@ -1,14 +1,15 @@
 package group
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/group"
 	"github.com/rigdev/rig/cmd/common"
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) delete(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) delete(ctx context.Context, cmd *cobra.Command, args []string) error {
 	identifier := ""
 	if len(args) > 0 {
 		identifier = args[0]

--- a/cmd/rig/cmd/group/get.go
+++ b/cmd/rig/cmd/group/get.go
@@ -1,6 +1,7 @@
 package group
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/bufbuild/connect-go"
@@ -11,11 +12,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) get(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
-
+func (c Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
-		ctx := c.Ctx
 		identifier := ""
 		if len(args) > 0 {
 			identifier = args[0]

--- a/cmd/rig/cmd/group/get_groups_for_user.go
+++ b/cmd/rig/cmd/group/get_groups_for_user.go
@@ -1,6 +1,7 @@
 package group
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/bufbuild/connect-go"
@@ -11,8 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) listGroupsForUser(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) listGroupsForUser(ctx context.Context, cmd *cobra.Command, args []string) error {
 	identifier := ""
 	if len(args) > 0 {
 		identifier = args[0]

--- a/cmd/rig/cmd/group/get_members.go
+++ b/cmd/rig/cmd/group/get_members.go
@@ -1,6 +1,7 @@
 package group
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/bufbuild/connect-go"
@@ -10,8 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) listMembers(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) listMembers(ctx context.Context, cmd *cobra.Command, args []string) error {
 	identifier := ""
 	if len(args) > 0 {
 		identifier = args[0]

--- a/cmd/rig/cmd/group/update.go
+++ b/cmd/rig/cmd/group/update.go
@@ -1,6 +1,7 @@
 package group
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/bufbuild/connect-go"
@@ -32,8 +33,7 @@ func (f groupField) String() string {
 	}
 }
 
-func (c Cmd) update(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) update(ctx context.Context, cmd *cobra.Command, args []string) error {
 	identifier := ""
 	if len(args) > 0 {
 		identifier = args[0]

--- a/cmd/rig/cmd/project/create.go
+++ b/cmd/rig/cmd/project/create.go
@@ -1,14 +1,15 @@
 package project
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/project"
 	"github.com/rigdev/rig/cmd/common"
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) create(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) create(ctx context.Context, cmd *cobra.Command, args []string) error {
 	if name == "" {
 		var err error
 		name, err = common.PromptInput("Project name:", common.ValidateNonEmptyOpt)

--- a/cmd/rig/cmd/project/delete.go
+++ b/cmd/rig/cmd/project/delete.go
@@ -1,13 +1,14 @@
 package project
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/project"
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) delete(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) delete(ctx context.Context, cmd *cobra.Command, args []string) error {
 	req := &project.DeleteRequest{}
 
 	_, err := c.Rig.Project().Delete(ctx, &connect.Request[project.DeleteRequest]{Msg: req})

--- a/cmd/rig/cmd/project/get.go
+++ b/cmd/rig/cmd/project/get.go
@@ -1,6 +1,8 @@
 package project
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/rigdev/rig-go-api/api/v1/project"
@@ -8,8 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) get(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error {
 	req := &project.GetRequest{}
 	resp, err := c.Rig.Project().Get(ctx, &connect.Request[project.GetRequest]{Msg: req})
 	if err != nil {

--- a/cmd/rig/cmd/project/get_settings.go
+++ b/cmd/rig/cmd/project/get_settings.go
@@ -1,6 +1,8 @@
 package project
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/rigdev/rig-go-api/api/v1/project/settings"
@@ -8,8 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) getSettings(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) getSettings(ctx context.Context, cmd *cobra.Command, args []string) error {
 	req := &settings.GetSettingsRequest{}
 	resp, err := c.Rig.ProjectSettings().GetSettings(ctx, &connect.Request[settings.GetSettingsRequest]{Msg: req})
 	if err != nil {

--- a/cmd/rig/cmd/project/list.go
+++ b/cmd/rig/cmd/project/list.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/bufbuild/connect-go"
@@ -11,8 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) list(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) list(ctx context.Context, cmd *cobra.Command, args []string) error {
 	req := &project.ListRequest{
 		Pagination: &model.Pagination{
 			Offset: uint32(offset),

--- a/cmd/rig/cmd/project/update.go
+++ b/cmd/rig/cmd/project/update.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/bufbuild/connect-go"
@@ -28,8 +29,7 @@ func (p projectField) String() string {
 	}
 }
 
-func (c Cmd) update(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) update(ctx context.Context, cmd *cobra.Command, args []string) error {
 	resp, err := c.Rig.Project().Get(ctx, &connect.Request[project.GetRequest]{Msg: &project.GetRequest{}})
 	if err != nil {
 		return err

--- a/cmd/rig/cmd/project/update_settings.go
+++ b/cmd/rig/cmd/project/update_settings.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -90,8 +91,7 @@ func (f settingsField) String() string {
 	}
 }
 
-func (c Cmd) updateSettings(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) updateSettings(ctx context.Context, cmd *cobra.Command, args []string) error {
 	res, err := c.Rig.ProjectSettings().GetSettings(ctx, &connect.Request[settings.GetSettingsRequest]{})
 	if err != nil {
 		return err

--- a/cmd/rig/cmd/project/use_project.go
+++ b/cmd/rig/cmd/project/use_project.go
@@ -10,8 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) use(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) use(ctx context.Context, cmd *cobra.Command, args []string) error {
 	var projectID string
 	var err error
 	if len(args) == 0 {

--- a/cmd/rig/cmd/root.go
+++ b/cmd/rig/cmd/root.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rigdev/rig/cmd/common"
 	"github.com/rigdev/rig/cmd/rig/cmd/auth"
 	"github.com/rigdev/rig/cmd/rig/cmd/base"
-	"github.com/rigdev/rig/cmd/rig/cmd/capsule/root"
+	capsule_root "github.com/rigdev/rig/cmd/rig/cmd/capsule/root"
 	"github.com/rigdev/rig/cmd/rig/cmd/cluster"
 	"github.com/rigdev/rig/cmd/rig/cmd/cmd_config"
 	"github.com/rigdev/rig/cmd/rig/cmd/config"
@@ -26,37 +26,26 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-type RootCmd struct {
+type Cmd struct {
 	fx.In
 
-	Ctx    context.Context
 	Rig    rig.Client
 	Cfg    *cmd_config.Config
 	Logger *zap.Logger
-
-	Dev            dev.Cmd
-	Capsule        root.Cmd
-	Auth           auth.Cmd
-	User           user.Cmd
-	ServiceAccount service_account.Cmd
-	Group          group.Cmd
-	Cluster        cluster.Cmd
-	Config         config.Cmd
-	Project        project.Cmd
 }
 
-func (r RootCmd) Execute() error {
+func Run() error {
 	rootCmd := &cobra.Command{
 		Use:               "rig",
 		Short:             "CLI tool for managing your Rig projects",
-		PersistentPreRunE: r.preRun,
+		PersistentPreRunE: base.Register(func(c Cmd) any { return c.preRun }),
 	}
 
 	license := &cobra.Command{
 		Use:               "license",
 		Short:             "Get License Information for the current project",
 		Args:              cobra.NoArgs,
-		RunE:              r.getLicenseInfo,
+		RunE:              base.Register(func(c Cmd) any { return c.getLicenseInfo }),
 		ValidArgsFunction: common.NoCompletions,
 		Annotations: map[string]string{
 			base.OmitProject: "",
@@ -64,31 +53,29 @@ func (r RootCmd) Execute() error {
 	}
 	rootCmd.AddCommand(license)
 
-	// database.Setup(rootCmd)
-	// storage.Setup(rootCmd)
-	r.Dev.Setup(rootCmd)
-	r.Capsule.Setup(rootCmd)
-	r.Auth.Setup(rootCmd)
-	r.User.Setup(rootCmd)
-	r.ServiceAccount.Setup(rootCmd)
-	r.Group.Setup(rootCmd)
-	r.Cluster.Setup(rootCmd)
-	r.Config.Setup(rootCmd)
-	r.Project.Setup(rootCmd)
+	dev.Setup(rootCmd)
+	capsule_root.Setup(rootCmd)
+	auth.Setup(rootCmd)
+	user.Setup(rootCmd)
+	service_account.Setup(rootCmd)
+	group.Setup(rootCmd)
+	cluster.Setup(rootCmd)
+	config.Setup(rootCmd)
+	project.Setup(rootCmd)
 	rootCmd.AddCommand(build.VersionCommand())
 
 	return rootCmd.Execute()
 }
 
-func (r RootCmd) preRun(cmd *cobra.Command, args []string) error {
-	return base.CheckAuth(cmd, r.Rig, r.Cfg)
+func (r Cmd) preRun(ctx context.Context, cmd *cobra.Command, args []string) error {
+	return base.CheckAuth(ctx, cmd, r.Rig, r.Cfg)
 }
 
-func (c RootCmd) getLicenseInfo(cmd *cobra.Command, args []string) error {
+func (c Cmd) getLicenseInfo(ctx context.Context, cmd *cobra.Command, args []string) error {
 	var plan project_api.Plan
 	var expiresAt *timestamppb.Timestamp
 
-	resp, err := c.Rig.Project().GetLicenseInfo(c.Ctx, &connect.Request[project_api.GetLicenseInfoRequest]{})
+	resp, err := c.Rig.Project().GetLicenseInfo(ctx, &connect.Request[project_api.GetLicenseInfoRequest]{})
 	if err != nil {
 		cmd.Println("Unable to get license info", err)
 		plan = project_api.Plan_PLAN_FREE

--- a/cmd/rig/cmd/service_account/create.go
+++ b/cmd/rig/cmd/service_account/create.go
@@ -1,14 +1,15 @@
 package service_account
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/service_account"
 	"github.com/rigdev/rig/cmd/common"
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) create(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) create(ctx context.Context, cmd *cobra.Command, args []string) error {
 	var name string
 	var err error
 

--- a/cmd/rig/cmd/service_account/delete.go
+++ b/cmd/rig/cmd/service_account/delete.go
@@ -1,6 +1,8 @@
 package service_account
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/service_account"
 	"github.com/rigdev/rig/cmd/common"
@@ -8,8 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) delete(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) delete(ctx context.Context, cmd *cobra.Command, args []string) error {
 	var id string
 	var err error
 

--- a/cmd/rig/cmd/service_account/get.go
+++ b/cmd/rig/cmd/service_account/get.go
@@ -1,6 +1,8 @@
 package service_account
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/rigdev/rig-go-api/api/v1/service_account"
@@ -9,8 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) list(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) list(ctx context.Context, cmd *cobra.Command, args []string) error {
 	resp, err := c.Rig.ServiceAccount().List(ctx, &connect.Request[service_account.ListRequest]{
 		Msg: &service_account.ListRequest{},
 	})

--- a/cmd/rig/cmd/user/add_member.go
+++ b/cmd/rig/cmd/user/add_member.go
@@ -1,14 +1,15 @@
 package user
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/group"
 	"github.com/rigdev/rig/cmd/common"
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) addMember(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) addMember(ctx context.Context, cmd *cobra.Command, args []string) error {
 	uidentifier := ""
 	if len(args) >= 1 {
 		uidentifier = args[0]

--- a/cmd/rig/cmd/user/create.go
+++ b/cmd/rig/cmd/user/create.go
@@ -1,14 +1,15 @@
 package user
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/user"
 	"github.com/rigdev/rig/cmd/common"
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) create(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) create(ctx context.Context, cmd *cobra.Command, args []string) error {
 	updates, err := common.GetUserAndPasswordUpdates(username, email, phoneNumber, password)
 	if err != nil {
 		return err

--- a/cmd/rig/cmd/user/delete.go
+++ b/cmd/rig/cmd/user/delete.go
@@ -1,14 +1,15 @@
 package user
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/user"
 	"github.com/rigdev/rig/cmd/common"
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) delete(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) delete(ctx context.Context, cmd *cobra.Command, args []string) error {
 	identifier := ""
 	if len(args) > 0 {
 		identifier = args[0]

--- a/cmd/rig/cmd/user/get_settings.go
+++ b/cmd/rig/cmd/user/get_settings.go
@@ -1,6 +1,8 @@
 package user
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/rigdev/rig-go-api/api/v1/user/settings"
@@ -8,8 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) getSettings(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) getSettings(ctx context.Context, cmd *cobra.Command, args []string) error {
 	res, err := c.Rig.UserSettings().GetSettings(ctx, &connect.Request[settings.GetSettingsRequest]{})
 	if err != nil {
 		return err

--- a/cmd/rig/cmd/user/list.go
+++ b/cmd/rig/cmd/user/list.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/bufbuild/connect-go"
@@ -11,11 +12,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) get(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
-
+func (c Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
-		ctx := c.Ctx
 		identifier := ""
 		if len(args) > 0 {
 			identifier = args[0]

--- a/cmd/rig/cmd/user/list_sessions.go
+++ b/cmd/rig/cmd/user/list_sessions.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/bufbuild/connect-go"
@@ -11,8 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) listSessions(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) listSessions(ctx context.Context, cmd *cobra.Command, args []string) error {
 	identifier := ""
 	if len(args) > 0 {
 		identifier = args[0]

--- a/cmd/rig/cmd/user/migrate.go
+++ b/cmd/rig/cmd/user/migrate.go
@@ -69,8 +69,7 @@ type firebaseUser struct {
 	CreatedAt     string `json:"createdAt"`
 }
 
-func (c Cmd) migrate(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) migrate(ctx context.Context, cmd *cobra.Command, args []string) error {
 	var err error
 	fields := []string{
 		platformFirebase.String(),

--- a/cmd/rig/cmd/user/remove_member.go
+++ b/cmd/rig/cmd/user/remove_member.go
@@ -1,14 +1,15 @@
 package user
 
 import (
+	"context"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/group"
 	"github.com/rigdev/rig/cmd/common"
 	"github.com/spf13/cobra"
 )
 
-func (c Cmd) removeMember(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) removeMember(ctx context.Context, cmd *cobra.Command, args []string) error {
 	uidentifier := ""
 	if len(args) > 1 {
 		uidentifier = args[1]

--- a/cmd/rig/cmd/user/update.go
+++ b/cmd/rig/cmd/user/update.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -84,8 +85,7 @@ func (f userProfileField) String() string {
 	}
 }
 
-func (c Cmd) update(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) update(ctx context.Context, cmd *cobra.Command, args []string) error {
 	identifier := ""
 	if len(args) > 0 {
 		identifier = args[0]

--- a/cmd/rig/cmd/user/update_settings.go
+++ b/cmd/rig/cmd/user/update_settings.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -108,8 +109,7 @@ func (f settingsField) String() string {
 	}
 }
 
-func (c Cmd) updateSettings(cmd *cobra.Command, args []string) error {
-	ctx := c.Ctx
+func (c Cmd) updateSettings(ctx context.Context, cmd *cobra.Command, args []string) error {
 	res, err := c.Rig.UserSettings().GetSettings(ctx, &connect.Request[settings.GetSettingsRequest]{})
 	if err != nil {
 		return err

--- a/cmd/rig/main.go
+++ b/cmd/rig/main.go
@@ -1,17 +1,13 @@
 package main
 
 import (
+	"log"
+
 	"github.com/rigdev/rig/cmd/rig/cmd"
-	"github.com/rigdev/rig/cmd/rig/cmd/base"
-	"go.uber.org/fx"
 )
 
 func main() {
-	fx.New(
-		base.Module,
-		fx.NopLogger,
-		fx.Invoke(func(r cmd.RootCmd) error {
-			return r.Execute()
-		}),
-	)
+	if err := cmd.Run(); err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
We're in a bit of a catch-22.
1. We don't want to construct dependencies for commands not in the current command chain
2. We want command dependencies encapsulated in a Cmd struct for ease of use and clarity
3. We need references to the Run, PreRun etc. functions before any Cobra parsing happens
4. These functions are instance methods on Cmd structs we cannot construct before command
parsing happens.

I found a solution, but I don't like it :(
