### PR TITLE
:children_crossing: CLI: Unify output-type flags

### DIFF
--- a/cmd/common/utils.go
+++ b/cmd/common/utils.go
@@ -19,8 +19,6 @@ import (
 	"github.com/rigdev/rig-go-sdk"
 	"github.com/rigdev/rig/pkg/errors"
 	"github.com/rigdev/rig/pkg/uuid"
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/reflect/protoreflect"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -221,10 +219,6 @@ func GetGroup(ctx context.Context, identifier string, nc rig.Client) (*group.Gro
 
 func FormatField(s string) string {
 	return strings.ToLower(strings.ReplaceAll(s, " ", "-"))
-}
-
-func ProtoToPrettyJson(m protoreflect.ProtoMessage) string {
-	return protojson.Format(m)
 }
 
 func FormatIntToSI(n uint64, decimals int) string {

--- a/cmd/rig/cmd/auth/get.go
+++ b/cmd/rig/cmd/auth/get.go
@@ -7,7 +7,7 @@ import (
 	"github.com/bufbuild/connect-go"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/rigdev/rig-go-api/api/v1/authentication"
-	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	"github.com/spf13/cobra"
 )
 
@@ -19,9 +19,8 @@ func (c *Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error 
 		return err
 	}
 
-	if outputJSON {
-		cmd.Println(common.ProtoToPrettyJson(res.Msg))
-		return nil
+	if base.Flags.OutputType != base.OutputTypePretty {
+		return base.FormatPrint(res.Msg)
 	}
 
 	ui := res.Msg.GetUserInfo()

--- a/cmd/rig/cmd/auth/setup.go
+++ b/cmd/rig/cmd/auth/setup.go
@@ -14,8 +14,6 @@ var (
 	authUserIdentifier string
 )
 
-var outputJSON bool
-
 type Cmd struct {
 	fx.In
 
@@ -64,8 +62,6 @@ func Setup(parent *cobra.Command) {
 		},
 		ValidArgsFunction: common.NoCompletions,
 	}
-	get.Flags().BoolVar(&outputJSON, "json", false, "Output as JSON")
-	get.RegisterFlagCompletionFunc("json", common.BoolCompletions)
 	auth.AddCommand(get)
 
 	parent.AddCommand(auth)

--- a/cmd/rig/cmd/base/common.go
+++ b/cmd/rig/cmd/base/common.go
@@ -1,9 +1,14 @@
 package base
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -22,4 +27,35 @@ func cmdPathContainsUsePrefix(cmd *cobra.Command, use string) bool {
 
 func skipChecks(cmd *cobra.Command) bool {
 	return cmdPathContainsUsePrefix(cmd, "completion") || cmdPathContainsUsePrefix(cmd, "help ")
+}
+
+func Format(v any, outputType OutputType) (string, error) {
+	switch outputType {
+	case OutputTypeJSON:
+		if v, ok := v.(protoreflect.ProtoMessage); ok {
+			return protojson.Format(v), nil
+		}
+		bytes, err := json.MarshalIndent(v, "", "  ")
+		if err != nil {
+			return "", err
+		}
+		return string(bytes), nil
+	case OutputTypeYAML:
+		bytes, err := yaml.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		return string(bytes), nil
+	default:
+		return "", fmt.Errorf("unexpected output type %v", outputType)
+	}
+}
+
+func FormatPrint(v any) error {
+	s, err := Format(v, Flags.OutputType)
+	if err != nil {
+		return err
+	}
+	fmt.Println(s)
+	return nil
 }

--- a/cmd/rig/cmd/base/flags.go
+++ b/cmd/rig/cmd/base/flags.go
@@ -1,0 +1,42 @@
+package base
+
+import "errors"
+
+type OutputType string
+
+const (
+	OutputTypeJSON   OutputType = "json"
+	OutputTypeYAML   OutputType = "yaml"
+	OutputTypePretty OutputType = "pretty"
+)
+
+// String is used both by fmt.Print and by Cobra in help text
+func (e *OutputType) String() string {
+	return string(*e)
+}
+
+// Set must have pointer receiver so it doesn't change the value of a copy
+func (e *OutputType) Set(v string) error {
+	switch v {
+	case string(OutputTypeJSON), string(OutputTypeYAML), string(OutputTypePretty):
+		*e = OutputType(v)
+		return nil
+	default:
+		return errors.New(`must be one of "json", "yaml", or "pretty"`)
+	}
+}
+
+// Type is only used in help text
+func (e *OutputType) Type() string {
+	return "OutputType"
+}
+
+type FlagsStruct struct {
+	OutputType     OutputType
+	NonInteractive bool
+}
+
+var Flags = FlagsStruct{
+	OutputType:     OutputTypePretty,
+	NonInteractive: false,
+}

--- a/cmd/rig/cmd/capsule/builddeploy/get_build.go
+++ b/cmd/rig/cmd/capsule/builddeploy/get_build.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rigdev/rig-go-api/api/v1/capsule"
 	"github.com/rigdev/rig-go-api/model"
 	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	capsule_cmd "github.com/rigdev/rig/cmd/rig/cmd/capsule"
 	"github.com/spf13/cobra"
 )
@@ -29,11 +30,8 @@ func (c *Cmd) getBuild(ctx context.Context, cmd *cobra.Command, args []string) e
 		return err
 	}
 
-	if outputJSON {
-		for _, b := range resp.Msg.GetBuilds() {
-			cmd.Println(common.ProtoToPrettyJson(b))
-		}
-		return nil
+	if base.Flags.OutputType != base.OutputTypePretty {
+		return base.FormatPrint(resp.Msg.GetBuilds())
 	}
 
 	t := table.NewWriter()

--- a/cmd/rig/cmd/capsule/builddeploy/setup.go
+++ b/cmd/rig/cmd/capsule/builddeploy/setup.go
@@ -24,7 +24,6 @@ var (
 )
 
 var (
-	outputJSON     bool
 	deploy         bool
 	skipImageCheck bool
 	remote         bool
@@ -94,10 +93,8 @@ func setupBuild(parent *cobra.Command) {
 			common.MaxArgsCompletionFilter(1),
 		),
 	}
-	buildGet.Flags().IntVarP(&offset, "offset", "o", 0, "offset")
+	buildGet.Flags().IntVar(&offset, "offset", 0, "offset")
 	buildGet.Flags().IntVarP(&limit, "limit", "l", 10, "limit")
-	buildGet.Flags().BoolVar(&outputJSON, "json", false, "output as json")
-	buildGet.RegisterFlagCompletionFunc("json", common.BoolCompletions)
 	buildGet.RegisterFlagCompletionFunc("offset", common.NoCompletions)
 	buildGet.RegisterFlagCompletionFunc("limit", common.NoCompletions)
 	build.AddCommand(buildGet)

--- a/cmd/rig/cmd/capsule/instance/get.go
+++ b/cmd/rig/cmd/capsule/instance/get.go
@@ -2,14 +2,13 @@ package instance
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
 	"github.com/bufbuild/connect-go"
 	"github.com/fatih/color"
 	"github.com/rigdev/rig-go-api/api/v1/capsule"
 	"github.com/rigdev/rig-go-api/api/v1/capsule/instance"
 	"github.com/rigdev/rig-go-api/model"
+	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	cmd_capsule "github.com/rigdev/rig/cmd/rig/cmd/capsule"
 	table2 "github.com/rodaine/table"
 	"github.com/spf13/cobra"
@@ -29,13 +28,8 @@ func (c *Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error 
 	}
 	instances := resp.Msg.GetInstances()
 
-	if outputJSON {
-		jsonStr, err := json.MarshalIndent(instances, "", "  ")
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(jsonStr))
-		return nil
+	if base.Flags.OutputType != base.OutputTypePretty {
+		return base.FormatPrint(instances)
 	}
 
 	headerFmt := color.New(color.FgBlue, color.Underline).SprintfFunc()

--- a/cmd/rig/cmd/capsule/instance/setup.go
+++ b/cmd/rig/cmd/capsule/instance/setup.go
@@ -24,7 +24,6 @@ var (
 )
 
 var (
-	outputJSON  bool
 	follow      bool
 	tty         bool
 	interactive bool
@@ -65,10 +64,8 @@ func Setup(parent *cobra.Command) {
 			common.MaxArgsCompletionFilter(1),
 		),
 	}
-	GetInstances.Flags().BoolVar(&outputJSON, "json", false, "output as json")
-	GetInstances.Flags().IntVarP(&offset, "offset", "o", 0, "offset for pagination")
+	GetInstances.Flags().IntVar(&offset, "offset", 0, "offset for pagination")
 	GetInstances.Flags().IntVarP(&limit, "limit", "l", 10, "limit for pagination")
-	GetInstances.RegisterFlagCompletionFunc("json", common.BoolCompletions)
 	GetInstances.RegisterFlagCompletionFunc("offset", common.NoCompletions)
 	GetInstances.RegisterFlagCompletionFunc("limit", common.NoCompletions)
 	instance.AddCommand(GetInstances)

--- a/cmd/rig/cmd/capsule/mount/setup.go
+++ b/cmd/rig/cmd/capsule/mount/setup.go
@@ -17,7 +17,6 @@ import (
 )
 
 var (
-	outputJSON  bool
 	secret      bool
 	forceDeploy bool
 )
@@ -59,8 +58,6 @@ func Setup(parent *cobra.Command) {
 		),
 	}
 	mountGet.Flags().StringVar(&dstPath, "download", "", "download the mount to specified path. If empty use current dir")
-	mountGet.Flags().BoolVar(&outputJSON, "json", false, "output as json")
-	mountGet.RegisterFlagCompletionFunc("json", common.BoolCompletions)
 	mount.AddCommand(mountGet)
 
 	mountSet := &cobra.Command{

--- a/cmd/rig/cmd/capsule/network/get.go
+++ b/cmd/rig/cmd/capsule/network/get.go
@@ -6,9 +6,8 @@ import (
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/rigdev/rig-go-api/api/v1/capsule"
-	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	capsule_cmd "github.com/rigdev/rig/cmd/rig/cmd/capsule"
-
 	"github.com/spf13/cobra"
 )
 
@@ -33,9 +32,8 @@ func (c *Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error 
 		}
 	}
 
-	if outputJSON {
-		cmd.Println(common.ProtoToPrettyJson(n))
-		return nil
+	if base.Flags.OutputType != base.OutputTypePretty {
+		return base.FormatPrint(n)
 	}
 
 	t := table.NewWriter()

--- a/cmd/rig/cmd/capsule/network/setup.go
+++ b/cmd/rig/cmd/capsule/network/setup.go
@@ -14,7 +14,6 @@ import (
 )
 
 var (
-	outputJSON  bool
 	forceDeploy bool
 )
 
@@ -58,8 +57,6 @@ func Setup(parent *cobra.Command) {
 			common.MaxArgsCompletionFilter(1),
 		),
 	}
-	networkGet.Flags().BoolVar(&outputJSON, "json", false, "output as json")
-	networkGet.RegisterFlagCompletionFunc("json", common.BoolCompletions)
 	network.AddCommand(networkGet)
 
 	parent.AddCommand(network)

--- a/cmd/rig/cmd/capsule/rollout/get.go
+++ b/cmd/rig/cmd/capsule/rollout/get.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/rigdev/rig-go-api/api/v1/capsule"
 	"github.com/rigdev/rig-go-api/model"
-	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	capsule_cmd "github.com/rigdev/rig/cmd/rig/cmd/capsule"
 	"github.com/rigdev/rig/pkg/errors"
 	"github.com/spf13/cobra"
@@ -51,11 +51,8 @@ func (c *Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error 
 		}
 	}
 
-	if outputJSON {
-		for _, r := range rollouts {
-			cmd.Println(common.ProtoToPrettyJson(r))
-		}
-		return nil
+	if base.Flags.OutputType != base.OutputTypePretty {
+		return base.FormatPrint(rollouts)
 	}
 
 	t := table.NewWriter()

--- a/cmd/rig/cmd/capsule/rollout/setup.go
+++ b/cmd/rig/cmd/capsule/rollout/setup.go
@@ -23,7 +23,6 @@ var (
 )
 
 var (
-	outputJSON  bool
 	forceDeploy bool
 )
 
@@ -58,10 +57,8 @@ func Setup(parent *cobra.Command) {
 			common.MaxArgsCompletionFilter(1),
 		),
 	}
-	rolloutGet.Flags().BoolVar(&outputJSON, "json", false, "output as json")
-	rolloutGet.Flags().IntVarP(&offset, "offset", "o", 0, "offset for pagination")
+	rolloutGet.Flags().IntVar(&offset, "offset", 0, "offset for pagination")
 	rolloutGet.Flags().IntVarP(&limit, "limit", "l", 10, "limit for pagination")
-	rolloutGet.RegisterFlagCompletionFunc("json", common.BoolCompletions)
 	rolloutGet.RegisterFlagCompletionFunc("offset", common.NoCompletions)
 	rolloutGet.RegisterFlagCompletionFunc("limit", common.NoCompletions)
 	rollout.AddCommand(rolloutGet)

--- a/cmd/rig/cmd/capsule/root/setup.go
+++ b/cmd/rig/cmd/capsule/root/setup.go
@@ -34,7 +34,6 @@ var (
 
 var (
 	interactive bool
-	outputJSON  bool
 	forceDeploy bool
 	follow      bool
 )
@@ -123,10 +122,8 @@ func Setup(parent *cobra.Command) {
 		RunE:              base.CtxWrap(cmd.get),
 		ValidArgsFunction: common.NoCompletions,
 	}
-	capsuleGet.Flags().BoolVar(&outputJSON, "json", false, "output as json")
-	capsuleGet.Flags().IntVarP(&offset, "offset", "o", 0, "offset for pagination")
+	capsuleGet.Flags().IntVar(&offset, "offset", 0, "offset for pagination")
 	capsuleGet.Flags().IntVarP(&limit, "limit", "l", 10, "limit for pagination")
-	capsuleGet.RegisterFlagCompletionFunc("json", common.BoolCompletions)
 	capsuleGet.RegisterFlagCompletionFunc("offset", common.NoCompletions)
 	capsuleGet.RegisterFlagCompletionFunc("limit", common.NoCompletions)
 	capsuleCmd.AddCommand(capsuleGet)

--- a/cmd/rig/cmd/capsule/scale/get.go
+++ b/cmd/rig/cmd/capsule/scale/get.go
@@ -2,36 +2,31 @@ package scale
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	capsule_api "github.com/rigdev/rig-go-api/api/v1/capsule"
+	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	"github.com/rigdev/rig/cmd/rig/cmd/capsule"
 	"github.com/spf13/cobra"
 )
 
-func (r Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error {
-	rollout, err := capsule.GetCurrentRollout(ctx, r.Rig)
+func (c *Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error {
+	rollout, err := capsule.GetCurrentRollout(ctx, c.Rig)
 	if err != nil {
 		return err
 	}
-	containerSettings, replicas, err := capsule.GetCurrentContainerResources(ctx, r.Rig)
+	containerSettings, replicas, err := capsule.GetCurrentContainerResources(ctx, c.Rig)
 	if err != nil {
 		return err
 	}
 
-	if outputJSON {
+	if base.Flags.OutputType != base.OutputTypePretty {
 		obj := scaleObj{
 			Replicas:      rollout.GetConfig().GetReplicas(),
 			ContainerSize: containerSettings.GetResources(),
 			Autoscaler:    rollout.GetConfig().GetHorizontalScale(),
 		}
-		bytes, err := json.MarshalIndent(&obj, "", "  ")
-		if err != nil {
-			return err
-		}
-		cmd.Println(string(bytes))
-		return nil
+		return base.FormatPrint(obj)
 	}
 
 	limits := containerSettings.GetResources().GetLimits()

--- a/cmd/rig/cmd/capsule/scale/setup.go
+++ b/cmd/rig/cmd/capsule/scale/setup.go
@@ -1,8 +1,6 @@
 package scale
 
 import (
-	"fmt"
-
 	"github.com/rigdev/rig-go-sdk"
 	"github.com/rigdev/rig/cmd/common"
 	"github.com/rigdev/rig/cmd/rig/cmd/base"
@@ -11,7 +9,6 @@ import (
 )
 
 var (
-	outputJSON          bool
 	disable             bool
 	overwriteAutoscaler bool
 	forceDeploy         bool
@@ -42,7 +39,6 @@ type Cmd struct {
 var cmd Cmd
 
 func initCmd(c Cmd) {
-	fmt.Println("initCmd capsule scale")
 	cmd.Rig = c.Rig
 }
 
@@ -60,8 +56,6 @@ func Setup(parent *cobra.Command) {
 		RunE:              base.CtxWrap(cmd.get),
 		ValidArgsFunction: common.NoCompletions,
 	}
-	scaleGet.Flags().BoolVar(&outputJSON, "json", false, "output as json")
-	scaleGet.RegisterFlagCompletionFunc("json", common.BoolCompletions)
 	scale.AddCommand(scaleGet)
 
 	scaleVertical := &cobra.Command{

--- a/cmd/rig/cmd/capsule/scale/vertical.go
+++ b/cmd/rig/cmd/capsule/scale/vertical.go
@@ -15,8 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func (r Cmd) vertical(ctx context.Context, cmd *cobra.Command, args []string) error {
-	container, _, err := capsule_cmd.GetCurrentContainerResources(ctx, r.Rig)
+func (c *Cmd) vertical(ctx context.Context, cmd *cobra.Command, args []string) error {
+	container, _, err := capsule_cmd.GetCurrentContainerResources(ctx, c.Rig)
 	if err != nil {
 		return nil
 	}
@@ -45,12 +45,12 @@ func (r Cmd) vertical(ctx context.Context, cmd *cobra.Command, args []string) er
 		},
 	})
 
-	_, err = r.Rig.Capsule().Deploy(ctx, req)
+	_, err = c.Rig.Capsule().Deploy(ctx, req)
 	if errors.IsFailedPrecondition(err) && errors.MessageOf(err) == "rollout already in progress" {
 		if forceDeploy {
-			_, err = capsule_cmd.AbortAndDeploy(ctx, r.Rig, capsule_cmd.CapsuleID, req)
+			_, err = capsule_cmd.AbortAndDeploy(ctx, c.Rig, capsule_cmd.CapsuleID, req)
 		} else {
-			_, err = capsule_cmd.PromptAbortAndDeploy(ctx, capsule_cmd.CapsuleID, r.Rig, req)
+			_, err = capsule_cmd.PromptAbortAndDeploy(ctx, capsule_cmd.CapsuleID, c.Rig, req)
 		}
 	}
 	if err != nil {

--- a/cmd/rig/cmd/group/get.go
+++ b/cmd/rig/cmd/group/get.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rigdev/rig-go-api/api/v1/group"
 	"github.com/rigdev/rig-go-api/model"
 	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	"github.com/spf13/cobra"
 )
 
@@ -23,9 +24,8 @@ func (c *Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error 
 			return err
 		}
 
-		if outputJSON {
-			cmd.Println(common.ProtoToPrettyJson(g))
-			return nil
+		if base.Flags.OutputType != base.OutputTypePretty {
+			return base.FormatPrint(g)
 		}
 
 		t := table.NewWriter()
@@ -51,11 +51,8 @@ func (c *Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error 
 		return err
 	}
 
-	if outputJSON {
-		for _, u := range resp.Msg.GetGroups() {
-			cmd.Println(common.ProtoToPrettyJson(u))
-		}
-		return nil
+	if base.Flags.OutputType != base.OutputTypePretty {
+		return base.FormatPrint(resp.Msg.GetGroups())
 	}
 
 	t := table.NewWriter()

--- a/cmd/rig/cmd/group/get_groups_for_user.go
+++ b/cmd/rig/cmd/group/get_groups_for_user.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rigdev/rig-go-api/api/v1/group"
 	"github.com/rigdev/rig-go-api/model"
 	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	"github.com/spf13/cobra"
 )
 
@@ -35,11 +36,8 @@ func (c *Cmd) listGroupsForUser(ctx context.Context, cmd *cobra.Command, args []
 		return err
 	}
 
-	if outputJSON {
-		for _, u := range resp.Msg.GetGroups() {
-			cmd.Println(common.ProtoToPrettyJson(u))
-		}
-		return nil
+	if base.Flags.OutputType != base.OutputTypePretty {
+		return base.FormatPrint(resp.Msg.GetGroups())
 	}
 
 	t := table.NewWriter()

--- a/cmd/rig/cmd/group/get_members.go
+++ b/cmd/rig/cmd/group/get_members.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/rigdev/rig-go-api/api/v1/group"
 	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	"github.com/spf13/cobra"
 )
 
@@ -30,11 +31,8 @@ func (c *Cmd) listMembers(ctx context.Context, cmd *cobra.Command, args []string
 		return err
 	}
 
-	if outputJSON {
-		for _, u := range resp.Msg.GetMembers() {
-			cmd.Println(common.ProtoToPrettyJson(u))
-		}
-		return nil
+	if base.Flags.OutputType != base.OutputTypePretty {
+		return base.FormatPrint(resp.Msg.GetMembers())
 	}
 
 	t := table.NewWriter()

--- a/cmd/rig/cmd/group/setup.go
+++ b/cmd/rig/cmd/group/setup.go
@@ -17,10 +17,6 @@ import (
 )
 
 var (
-	outputJSON bool
-)
-
-var (
 	offset int
 	limit  int
 )
@@ -94,10 +90,8 @@ func Setup(parent *cobra.Command) {
 			common.MaxArgsCompletionFilter(1),
 		),
 	}
-	get.Flags().BoolVar(&outputJSON, "json", false, "Output as JSON")
 	get.Flags().IntVarP(&limit, "limit", "l", 10, "limit the number of groups to return")
-	get.Flags().IntVarP(&offset, "offset", "o", 0, "offset the number of groups to return")
-	get.RegisterFlagCompletionFunc("json", common.BoolCompletions)
+	get.Flags().IntVar(&offset, "offset", 0, "offset the number of groups to return")
 	get.RegisterFlagCompletionFunc("limit", common.NoCompletions)
 	get.RegisterFlagCompletionFunc("offset", common.NoCompletions)
 	group.AddCommand(get)
@@ -112,10 +106,8 @@ func Setup(parent *cobra.Command) {
 			common.MaxArgsCompletionFilter(1),
 		),
 	}
-	getMembers.Flags().BoolVar(&outputJSON, "json", false, "Output as JSON")
 	getMembers.Flags().IntVarP(&limit, "limit", "l", 10, "limit the number of members to return")
-	getMembers.Flags().IntVarP(&offset, "offset", "o", 0, "offset the number of members to return")
-	getMembers.RegisterFlagCompletionFunc("json", common.BoolCompletions)
+	getMembers.Flags().IntVar(&offset, "offset", 0, "offset the number of members to return")
 	getMembers.RegisterFlagCompletionFunc("limit", common.NoCompletions)
 	getMembers.RegisterFlagCompletionFunc("offset", common.NoCompletions)
 	group.AddCommand(getMembers)
@@ -130,10 +122,8 @@ func Setup(parent *cobra.Command) {
 			common.MaxArgsCompletionFilter(1),
 		),
 	}
-	getGroupsForUser.Flags().BoolVar(&outputJSON, "json", false, "Output as JSON")
 	getGroupsForUser.Flags().IntVarP(&limit, "limit", "l", 10, "limit the number of groups to return")
-	getGroupsForUser.Flags().IntVarP(&offset, "offset", "o", 0, "offset the number of groups to return")
-	getGroupsForUser.RegisterFlagCompletionFunc("json", common.BoolCompletions)
+	getGroupsForUser.Flags().IntVar(&offset, "offset", 0, "offset the number of groups to return")
 	getGroupsForUser.RegisterFlagCompletionFunc("limit", common.NoCompletions)
 	getGroupsForUser.RegisterFlagCompletionFunc("offset", common.NoCompletions)
 	group.AddCommand(getGroupsForUser)

--- a/cmd/rig/cmd/project/get.go
+++ b/cmd/rig/cmd/project/get.go
@@ -6,7 +6,7 @@ import (
 	"github.com/bufbuild/connect-go"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/rigdev/rig-go-api/api/v1/project"
-	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	"github.com/spf13/cobra"
 )
 
@@ -17,9 +17,8 @@ func (c *Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error 
 		return err
 	}
 
-	if outputJSON {
-		cmd.Println(common.ProtoToPrettyJson(resp.Msg.GetProject()))
-		return nil
+	if base.Flags.OutputType != base.OutputTypePretty {
+		return base.FormatPrint(resp.Msg.GetProject())
 	}
 
 	t := table.NewWriter()

--- a/cmd/rig/cmd/project/get_settings.go
+++ b/cmd/rig/cmd/project/get_settings.go
@@ -6,7 +6,7 @@ import (
 	"github.com/bufbuild/connect-go"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/rigdev/rig-go-api/api/v1/project/settings"
-	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	"github.com/spf13/cobra"
 )
 
@@ -18,9 +18,8 @@ func (c *Cmd) getSettings(ctx context.Context, cmd *cobra.Command, args []string
 	}
 	set := resp.Msg.GetSettings()
 
-	if outputJSON {
-		cmd.Println(common.ProtoToPrettyJson(set))
-		return nil
+	if base.Flags.OutputType != base.OutputTypePretty {
+		return base.FormatPrint(set)
 	}
 
 	dockerRegistries := []table.Row{}

--- a/cmd/rig/cmd/project/list.go
+++ b/cmd/rig/cmd/project/list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/rigdev/rig-go-api/api/v1/project"
 	"github.com/rigdev/rig-go-api/model"
-	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	"github.com/spf13/cobra"
 )
 
@@ -25,11 +25,8 @@ func (c *Cmd) list(ctx context.Context, cmd *cobra.Command, args []string) error
 		return err
 	}
 
-	if outputJSON {
-		for _, p := range resp.Msg.GetProjects() {
-			cmd.Println(common.ProtoToPrettyJson(p))
-		}
-		return nil
+	if base.Flags.OutputType != base.OutputTypePretty {
+		return base.FormatPrint(resp.Msg.GetProjects())
 	}
 
 	t := table.NewWriter()

--- a/cmd/rig/cmd/project/setup.go
+++ b/cmd/rig/cmd/project/setup.go
@@ -27,7 +27,6 @@ var (
 )
 
 var (
-	outputJSON bool
 	useProject bool
 )
 
@@ -60,8 +59,6 @@ func Setup(parent *cobra.Command) {
 		RunE:              base.CtxWrap(cmd.getSettings),
 		ValidArgsFunction: common.NoCompletions,
 	}
-	getSettings.Flags().BoolVar(&outputJSON, "json", false, "Output as JSON")
-	getSettings.RegisterFlagCompletionFunc("json", common.BoolCompletions)
 	project.AddCommand(getSettings)
 
 	updateSettings := &cobra.Command{
@@ -128,8 +125,6 @@ func Setup(parent *cobra.Command) {
 		RunE:              base.CtxWrap(cmd.get),
 		ValidArgsFunction: common.NoCompletions,
 	}
-	getProject.Flags().BoolVar(&outputJSON, "json", false, "Output as JSON")
-	getProject.RegisterFlagCompletionFunc("json", common.BoolCompletions)
 	project.AddCommand(getProject)
 
 	updateProject := &cobra.Command{
@@ -170,10 +165,8 @@ func Setup(parent *cobra.Command) {
 		},
 		ValidArgsFunction: common.NoCompletions,
 	}
-	listProjects.Flags().IntVarP(&offset, "offset", "o", 0, "Offset")
+	listProjects.Flags().IntVar(&offset, "offset", 0, "Offset")
 	listProjects.Flags().IntVarP(&limit, "limit", "l", 10, "Limit")
-	listProjects.Flags().BoolVar(&outputJSON, "json", false, "Output as JSON")
-	listProjects.RegisterFlagCompletionFunc("json", common.BoolCompletions)
 	listProjects.RegisterFlagCompletionFunc("offset", common.NoCompletions)
 	listProjects.RegisterFlagCompletionFunc("limit", common.NoCompletions)
 	project.AddCommand(listProjects)

--- a/cmd/rig/cmd/root.go
+++ b/cmd/rig/cmd/root.go
@@ -53,6 +53,7 @@ func Run() error {
 			},
 		),
 	}
+	rootCmd.PersistentFlags().VarP(&base.Flags.OutputType, "output", "o", "output type. One of json,yaml,pretty.")
 
 	license := &cobra.Command{
 		Use:               "license",

--- a/cmd/rig/cmd/service_account/get.go
+++ b/cmd/rig/cmd/service_account/get.go
@@ -6,7 +6,7 @@ import (
 	"github.com/bufbuild/connect-go"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/rigdev/rig-go-api/api/v1/service_account"
-	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	"github.com/rigdev/rig/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -35,11 +35,8 @@ func (c *Cmd) list(ctx context.Context, cmd *cobra.Command, args []string) error
 		}
 	}
 
-	if outputJSON {
-		for _, cred := range serviceAccounts {
-			cmd.Println(common.ProtoToPrettyJson(cred))
-		}
-		return nil
+	if base.Flags.OutputType != base.OutputTypePretty {
+		return base.FormatPrint(serviceAccounts)
 	}
 
 	t := table.NewWriter()

--- a/cmd/rig/cmd/service_account/setup.go
+++ b/cmd/rig/cmd/service_account/setup.go
@@ -15,10 +15,6 @@ import (
 )
 
 var (
-	outputJSON bool
-)
-
-var (
 	offset int
 	limit  int
 )
@@ -62,10 +58,8 @@ func Setup(parent *cobra.Command) {
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: base.CtxWrapCompletion(cmd.completions),
 	}
-	get.Flags().BoolVar(&outputJSON, "json", false, "Output as JSON")
-	get.Flags().IntVarP(&offset, "offset", "o", 0, "offset")
+	get.Flags().IntVar(&offset, "offset", 0, "offset")
 	get.Flags().IntVarP(&limit, "limit", "l", 10, "limit")
-	get.RegisterFlagCompletionFunc("json", common.BoolCompletions)
 	get.RegisterFlagCompletionFunc("offset", common.NoCompletions)
 	get.RegisterFlagCompletionFunc("limit", common.NoCompletions)
 

--- a/cmd/rig/cmd/user/get_settings.go
+++ b/cmd/rig/cmd/user/get_settings.go
@@ -6,7 +6,7 @@ import (
 	"github.com/bufbuild/connect-go"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/rigdev/rig-go-api/api/v1/user/settings"
-	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	"github.com/spf13/cobra"
 )
 
@@ -17,9 +17,8 @@ func (c *Cmd) getSettings(ctx context.Context, cmd *cobra.Command, args []string
 	}
 	settings := res.Msg.GetSettings()
 
-	if outputJson {
-		cmd.Println(common.ProtoToPrettyJson(settings))
-		return nil
+	if base.Flags.OutputType != base.OutputTypePretty {
+		return base.FormatPrint(settings)
 	}
 
 	rows_login := []table.Row{}

--- a/cmd/rig/cmd/user/list.go
+++ b/cmd/rig/cmd/user/list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rigdev/rig-go-api/api/v1/user"
 	"github.com/rigdev/rig-go-api/model"
 	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	"github.com/spf13/cobra"
 )
 
@@ -23,9 +24,8 @@ func (c *Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error 
 			return err
 		}
 
-		if outputJson {
-			cmd.Println(common.ProtoToPrettyJson(u))
-			return nil
+		if base.Flags.OutputType != base.OutputTypePretty {
+			return base.FormatPrint(u)
 		}
 
 		t := table.NewWriter()
@@ -58,11 +58,8 @@ func (c *Cmd) get(ctx context.Context, cmd *cobra.Command, args []string) error 
 		return err
 	}
 
-	if outputJson {
-		for _, u := range resp.Msg.GetUsers() {
-			cmd.Println(common.ProtoToPrettyJson(u))
-		}
-		return nil
+	if base.Flags.OutputType != base.OutputTypePretty {
+		return base.FormatPrint(resp.Msg.GetUsers())
 	}
 
 	t := table.NewWriter()

--- a/cmd/rig/cmd/user/list_sessions.go
+++ b/cmd/rig/cmd/user/list_sessions.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rigdev/rig-go-api/api/v1/user"
 	"github.com/rigdev/rig-go-api/model"
 	"github.com/rigdev/rig/cmd/common"
+	"github.com/rigdev/rig/cmd/rig/cmd/base"
 	"github.com/spf13/cobra"
 )
 
@@ -33,11 +34,8 @@ func (c *Cmd) listSessions(ctx context.Context, cmd *cobra.Command, args []strin
 		return err
 	}
 
-	if outputJson {
-		for _, s := range resp.Msg.GetSessions() {
-			cmd.Println(common.ProtoToPrettyJson(s))
-		}
-		return nil
+	if base.Flags.OutputType != base.OutputTypePretty {
+		return base.FormatPrint(resp.Msg.GetSessions())
 	}
 
 	t := table.NewWriter()

--- a/cmd/rig/cmd/user/setup.go
+++ b/cmd/rig/cmd/user/setup.go
@@ -38,10 +38,6 @@ var (
 	groupIdentifier string
 )
 
-var (
-	outputJson bool
-)
-
 type Cmd struct {
 	fx.In
 
@@ -126,10 +122,8 @@ func Setup(parent *cobra.Command) {
 			common.MaxArgsCompletionFilter(1)),
 		Args: cobra.MaximumNArgs(1),
 	}
-	get.Flags().IntVarP(&offset, "offset", "o", 0, "offset for pagination")
+	get.Flags().IntVar(&offset, "offset", 0, "offset for pagination")
 	get.Flags().IntVarP(&limit, "limit", "l", 10, "limit for pagination")
-	get.Flags().BoolVar(&outputJson, "json", false, "output as json")
-	get.RegisterFlagCompletionFunc("json", common.BoolCompletions)
 	get.RegisterFlagCompletionFunc("offset", common.NoCompletions)
 	get.RegisterFlagCompletionFunc("limit", common.NoCompletions)
 	user.AddCommand(get)
@@ -156,10 +150,8 @@ func Setup(parent *cobra.Command) {
 			common.MaxArgsCompletionFilter(1),
 		),
 	}
-	getSessions.Flags().IntVarP(&offset, "offset", "o", 0, "offset for pagination")
+	getSessions.Flags().IntVar(&offset, "offset", 0, "offset for pagination")
 	getSessions.Flags().IntVarP(&limit, "limit", "l", 10, "limit for pagination")
-	getSessions.Flags().BoolVar(&outputJson, "json", false, "output as json")
-	getSessions.RegisterFlagCompletionFunc("json", common.BoolCompletions)
 	getSessions.RegisterFlagCompletionFunc("offset", common.NoCompletions)
 	getSessions.RegisterFlagCompletionFunc("limit", common.NoCompletions)
 	user.AddCommand(getSessions)
@@ -171,8 +163,6 @@ func Setup(parent *cobra.Command) {
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: common.NoCompletions,
 	}
-	getSettings.Flags().BoolVar(&outputJson, "json", false, "output as json")
-	getSettings.RegisterFlagCompletionFunc("json", common.BoolCompletions)
 	user.AddCommand(getSettings)
 
 	updateSettings := &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/docker/cli v24.0.0+incompatible // indirect
 	github.com/evanphx/json-patch v5.7.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-logr/zapr v1.2.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/safetext v0.0.0-20220905092116-b49f7bc46da2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0X
 github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=


### PR DESCRIPTION
Introduce a new root-level flag --output which can be either
json, yaml or pretty (defaults to pretty) and remove all the individual
--json flags.
This makes the Rig cli similar to kubectl in that you can give
-oyaml/-ojson and change the output format.
