### PR TITLE
:memo: Add resource API documentation

### DIFF
--- a/docs/crd-ref-docs/config.yaml
+++ b/docs/crd-ref-docs/config.yaml
@@ -1,0 +1,15 @@
+processor:
+  # RE2 regular expressions describing types that should be excluded from the generated documentation.
+  ignoreTypes:
+    - "(Capsule)List$"
+    - "(Capsule)Scale$"
+    - "(Capsule)Status$"
+  # RE2 regular expressions describing type fields that should be excluded from the generated documentation.
+  ignoreFields:
+    - "status$"
+    - "scale$"
+    - "TypeMeta$"
+
+render:
+  # Version of Kubernetes to use when generating links to Kubernetes API documentation.
+  kubernetesVersion: 1.28

--- a/docs/crd-ref-docs/v1alpha2-config.yaml
+++ b/docs/crd-ref-docs/v1alpha2-config.yaml
@@ -1,0 +1,13 @@
+processor:
+  # RE2 regular expressions describing types that should be excluded from the generated documentation.
+  ignoreTypes:
+    - "(Capsule)List$"
+    - "(Capsule)Status$"
+  # RE2 regular expressions describing type fields that should be excluded from the generated documentation.
+  ignoreFields:
+    - "status$"
+    - "TypeMeta$"
+
+render:
+  # Version of Kubernetes to use when generating links to Kubernetes API documentation.
+  kubernetesVersion: 1.28

--- a/docs/docs/api.mdx
+++ b/docs/docs/api.mdx
@@ -1,0 +1,11 @@
+# API Reference
+
+For reference of each of our api groups see their documentation:
+
+- [config.rig.dev/v1alpha1](/api/config/v1alpha1)
+  - [OperatorConfig](/api/config/v1alpha1#operatorconfig)
+  - [PlatformConfig](/api/config/v1alpha1#platformconfig)
+- [rig.dev/v1alpha1](/api/v1alpha1)
+  - [Capsule](/api/v1alpha1#capsule)
+- [rig.dev/v1alpha2](/api/v1alpha2)
+  - [Capsule](/api/v1alpha2#capsule)

--- a/docs/docs/api/config/v1alpha1.md
+++ b/docs/docs/api/config/v1alpha1.md
@@ -1,0 +1,433 @@
+# API Reference
+
+## Packages
+- [config.rig.dev/v1alpha1](#configrigdevv1alpha1)
+
+
+## config.rig.dev/v1alpha1
+
+Package v1alpha1 contains API Schema definitions for the config v1alpha1 API group
+
+### Resource Types
+- [OperatorConfig](#operatorconfig)
+- [PlatformConfig](#platformconfig)
+
+
+
+#### Auth
+
+
+
+
+
+_Appears in:_
+- [PlatformConfig](#platformconfig)
+
+| Field | Description |
+| --- | --- |
+| `secret` _string_ |  |
+| `certificateFile` _string_ |  |
+| `certificateKeyFile` _string_ |  |
+
+
+#### CertManagerConfig
+
+
+
+
+
+_Appears in:_
+- [OperatorConfig](#operatorconfig)
+
+| Field | Description |
+| --- | --- |
+| `clusterIssuer` _string_ | ClusterIssuer to use for issueing ingress certificates |
+| `createCertificateResources` _boolean_ | CreateCertificateResources specifies wether to create Certificate resources. If this is not enabled we will use ingress annotations. This is handy in environments where the ingress-shim isen't enabled. |
+
+
+#### Client
+
+
+
+
+
+_Appears in:_
+- [PlatformConfig](#platformconfig)
+
+| Field | Description |
+| --- | --- |
+| `postgres` _[ClientPostgres](#clientpostgres)_ | Postgres holds configuration for the postgres client. |
+| `mongo` _[ClientMongo](#clientmongo)_ | Mongo holds configuration for the Mongo client. |
+| `docker` _[ClientDocker](#clientdocker)_ | Docker sets the host for the Docker client. |
+| `mailjet` _[ClientMailjet](#clientmailjet)_ | Mailjet sets the API key and secret for the Mailjet client. |
+| `smtp` _[ClientSMTP](#clientsmtp)_ | SMTP sets the host, port, username and password for the SMTP client. |
+| `operator` _[ClientOperator](#clientoperator)_ | Operator sets the base url for the Operator client. |
+
+
+#### ClientDocker
+
+
+
+
+
+_Appears in:_
+- [Client](#client)
+
+| Field | Description |
+| --- | --- |
+| `host` _string_ |  |
+
+
+#### ClientMailjet
+
+
+
+
+
+_Appears in:_
+- [Client](#client)
+
+| Field | Description |
+| --- | --- |
+| `apiKey` _string_ |  |
+| `secretKey` _string_ |  |
+
+
+#### ClientMongo
+
+
+
+
+
+_Appears in:_
+- [Client](#client)
+
+| Field | Description |
+| --- | --- |
+| `user` _string_ |  |
+| `password` _string_ |  |
+| `host` _string_ | Host of the mongo server. This is both the host and port. |
+
+
+#### ClientOperator
+
+
+
+
+
+_Appears in:_
+- [Client](#client)
+
+| Field | Description |
+| --- | --- |
+| `baseUrl` _string_ |  |
+
+
+#### ClientPostgres
+
+
+
+
+
+_Appears in:_
+- [Client](#client)
+
+| Field | Description |
+| --- | --- |
+| `user` _string_ |  |
+| `password` _string_ |  |
+| `host` _string_ |  |
+| `port` _integer_ |  |
+| `database` _string_ | Database in the postgres server to use |
+| `insecure` _boolean_ | Use SSL when connecting to the postgres server |
+
+
+#### ClientSMTP
+
+
+
+
+
+_Appears in:_
+- [Client](#client)
+
+| Field | Description |
+| --- | --- |
+| `host` _string_ |  |
+| `port` _integer_ |  |
+| `username` _string_ |  |
+| `password` _string_ |  |
+
+
+#### Cluster
+
+
+
+
+
+_Appears in:_
+- [PlatformConfig](#platformconfig)
+
+| Field | Description |
+| --- | --- |
+| `type` _[ClusterType](#clustertype)_ | Type of the cluster - either docker or k8s |
+| `devRegistry` _[DevRegistry](#devregistry)_ |  |
+| `git` _[ClusterGit](#clustergit)_ |  |
+
+
+#### ClusterGit
+
+
+
+
+
+_Appears in:_
+- [Cluster](#cluster)
+
+| Field | Description |
+| --- | --- |
+| `url` _string_ |  |
+| `branch` _string_ |  |
+| `pathPrefix` _string_ |  |
+| `credentials` _[GitCredentials](#gitcredentials)_ |  |
+| `author` _[GitAuthor](#gitauthor)_ |  |
+| `templates` _[GitTemplates](#gittemplates)_ |  |
+
+
+#### ClusterType
+
+_Underlying type:_ _string_
+
+
+
+_Appears in:_
+- [Cluster](#cluster)
+
+
+
+#### DevRegistry
+
+
+
+
+
+_Appears in:_
+- [Cluster](#cluster)
+
+| Field | Description |
+| --- | --- |
+| `host` _string_ |  |
+| `clusterHost` _string_ |  |
+
+
+#### Email
+
+
+
+
+
+_Appears in:_
+- [PlatformConfig](#platformconfig)
+
+| Field | Description |
+| --- | --- |
+| `from` _string_ |  |
+| `type` _string_ |  |
+
+
+
+
+#### GitAuthor
+
+
+
+
+
+_Appears in:_
+- [ClusterGit](#clustergit)
+
+| Field | Description |
+| --- | --- |
+| `name` _string_ |  |
+| `email` _string_ |  |
+
+
+#### GitCredentials
+
+
+
+
+
+_Appears in:_
+- [ClusterGit](#clustergit)
+
+| Field | Description |
+| --- | --- |
+| `https` _[HTTPSCredential](#httpscredential)_ |  |
+| `ssh` _[SSHCredential](#sshcredential)_ |  |
+
+
+#### GitTemplates
+
+
+
+
+
+_Appears in:_
+- [ClusterGit](#clustergit)
+
+| Field | Description |
+| --- | --- |
+| `rollout` _string_ |  |
+| `delete` _string_ |  |
+
+
+#### HTTPSCredential
+
+
+
+
+
+_Appears in:_
+- [GitCredentials](#gitcredentials)
+
+| Field | Description |
+| --- | --- |
+| `username` _string_ |  |
+| `password` _string_ |  |
+
+
+#### IngressConfig
+
+
+
+
+
+_Appears in:_
+- [OperatorConfig](#operatorconfig)
+
+| Field | Description |
+| --- | --- |
+| `annotations` _object (keys:string, values:string)_ | Annotations for all ingress resources created. |
+| `className` _string_ | ClassName specifies the default ingress class to use for all ingress resources created. |
+
+
+#### Logging
+
+
+
+
+
+_Appears in:_
+- [PlatformConfig](#platformconfig)
+
+| Field | Description |
+| --- | --- |
+| `devMode` _boolean_ | DevModeEnabled enables verbose logs and changes the logging format to be more human readable. |
+| `level` _[Level](#level)_ | Level sets the granularity of logging |
+
+
+#### OAuth
+
+
+
+
+
+_Appears in:_
+- [PlatformConfig](#platformconfig)
+
+| Field | Description |
+| --- | --- |
+| `google` _[OAuthClientCredentials](#oauthclientcredentials)_ |  |
+| `github` _[OAuthClientCredentials](#oauthclientcredentials)_ |  |
+| `facebook` _[OAuthClientCredentials](#oauthclientcredentials)_ |  |
+
+
+#### OAuthClientCredentials
+
+
+
+
+
+_Appears in:_
+- [OAuth](#oauth)
+
+| Field | Description |
+| --- | --- |
+| `clientId` _string_ |  |
+| `clientSecret` _string_ |  |
+
+
+#### OperatorConfig
+
+
+
+OperatorConfig is the Schema for the configs API
+
+
+
+| Field | Description |
+| --- | --- |
+| `apiVersion` _string_ | `config.rig.dev/v1alpha1`
+| `kind` _string_ | `OperatorConfig`
+| `webhooksEnabled` _boolean_ | WebhooksEnabled set wether or not webhooks should be enabled. When enabled a certificate should be mounted at the webhook server certificate path. Defaults to true if omitted. |
+| `devModeEnabled` _boolean_ | DevModeEnabled enables verbose logs and changes the logging format to be more human readable. |
+| `leaderElectionEnabled` _boolean_ | LeaderElectionEnabled enables leader election when running multiple instances of the operator. |
+| `certManager` _[CertManagerConfig](#certmanagerconfig)_ | Certmanager holds configuration for how the operator should create certificates for ingress resources. |
+| `ingress` _[IngressConfig](#ingressconfig)_ | Ingress holds the configuration for ingress resources created by the operator. |
+
+
+#### PlatformConfig
+
+
+
+OperatorConfig is the Schema for the configs API
+
+
+
+| Field | Description |
+| --- | --- |
+| `apiVersion` _string_ | `config.rig.dev/v1alpha1`
+| `kind` _string_ | `PlatformConfig`
+| `port` _integer_ | Port sets the port the platform should listen on |
+| `publicUrl` _string_ | PublicUrl sets the public url for the platform. This is used for generating urls for the platform when using oauth2. |
+| `telemetryEnabled` _boolean_ |  |
+| `auth` _[Auth](#auth)_ |  |
+| `client` _[Client](#client)_ | Client holds configuration for clients used in the platform. |
+| `repository` _[Repository](#repository)_ | Repository specifies the type of db to use along with secret key |
+| `oauth` _[OAuth](#oauth)_ | OAuth holds configuration for oauth2 clients, namely google, github and facebook. |
+| `cluster` _[Cluster](#cluster)_ |  |
+| `email` _[Email](#email)_ | Email holds configuration for sending emails. Either using mailjet or using SMTP |
+| `logging` _[Logging](#logging)_ | Loggin holds information about the granularity of logging |
+
+
+#### Repository
+
+
+
+
+
+_Appears in:_
+- [PlatformConfig](#platformconfig)
+
+| Field | Description |
+| --- | --- |
+| `store` _string_ | Type of db to use |
+| `secret` _string_ |  |
+
+
+#### SSHCredential
+
+
+
+
+
+_Appears in:_
+- [GitCredentials](#gitcredentials)
+
+| Field | Description |
+| --- | --- |
+| `privateKey` _string_ |  |
+| `password` _string_ |  |
+
+

--- a/docs/docs/api/v1alpha1.md
+++ b/docs/docs/api/v1alpha1.md
@@ -1,0 +1,233 @@
+# API Reference
+
+## Packages
+- [rig.dev/v1alpha1](#rigdevv1alpha1)
+
+
+## rig.dev/v1alpha1
+
+Package v1alpha1 contains API Schema definitions for the  v1alpha1 API group
+
+### Resource Types
+- [Capsule](#capsule)
+
+
+
+#### CPUTarget
+
+
+
+CPUTarget defines an autoscaler target for the CPU metric If empty, no autoscaling will be done
+
+_Appears in:_
+- [HorizontalScale](#horizontalscale)
+
+| Field | Description |
+| --- | --- |
+| `averageUtilizationPercentage` _integer_ |  |
+
+
+#### Capsule
+
+
+
+Capsule is the Schema for the capsules API
+
+
+
+| Field | Description |
+| --- | --- |
+| `apiVersion` _string_ | `rig.dev/v1alpha1`
+| `kind` _string_ | `Capsule`
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `spec` _[CapsuleSpec](#capsulespec)_ |  |
+
+
+#### CapsuleInterface
+
+
+
+CapsuleInterface defines an interface for a capsule
+
+_Appears in:_
+- [CapsuleSpec](#capsulespec)
+
+| Field | Description |
+| --- | --- |
+| `name` _string_ |  |
+| `port` _integer_ |  |
+| `public` _[CapsulePublicInterface](#capsulepublicinterface)_ |  |
+
+
+#### CapsuleInterfaceIngress
+
+_Underlying type:_ _[struct{Host string "json:\"host\""}](#struct{host-string-"json:\"host\""})_
+
+CapsuleInterfaceIngress defines that the interface should be exposed as http ingress
+
+_Appears in:_
+- [CapsulePublicInterface](#capsulepublicinterface)
+
+
+
+#### CapsuleInterfaceLoadBalancer
+
+_Underlying type:_ _[struct{Port int32 "json:\"port\""; NodePort int32 "json:\"nodePort,omitempty\""}](#struct{port-int32-"json:\"port\"";-nodeport-int32-"json:\"nodeport,omitempty\""})_
+
+CapsuleInterfaceLoadBalancer defines that the interface should be exposed as a L4 loadbalancer
+
+_Appears in:_
+- [CapsulePublicInterface](#capsulepublicinterface)
+
+
+
+#### CapsulePublicInterface
+
+
+
+CapsulePublicInterface defines how to publicly expose the interface
+
+_Appears in:_
+- [CapsuleInterface](#capsuleinterface)
+
+| Field | Description |
+| --- | --- |
+| `ingress` _[CapsuleInterfaceIngress](#capsuleinterfaceingress)_ |  |
+| `loadBalancer` _[CapsuleInterfaceLoadBalancer](#capsuleinterfaceloadbalancer)_ |  |
+
+
+#### CapsuleSpec
+
+
+
+CapsuleSpec defines the desired state of Capsule
+
+_Appears in:_
+- [Capsule](#capsule)
+
+| Field | Description |
+| --- | --- |
+| `replicas` _integer_ |  |
+| `image` _string_ |  |
+| `command` _string_ |  |
+| `args` _string array_ |  |
+| `interfaces` _[CapsuleInterface](#capsuleinterface) array_ |  |
+| `env` _[Env](#env)_ |  |
+| `files` _[File](#file) array_ |  |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ |  |
+| `imagePullSecret` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ |  |
+| `horizontalScale` _[HorizontalScale](#horizontalscale)_ |  |
+| `serviceAccountName` _string_ |  |
+| `nodeSelector` _object (keys:string, values:string)_ |  |
+
+
+#### DeploymentStatus
+
+
+
+
+
+_Appears in:_
+- [CapsuleStatus](#capsulestatus)
+
+| Field | Description |
+| --- | --- |
+| `state` _string_ |  |
+| `message` _string_ |  |
+
+
+#### Env
+
+
+
+Env defines what secrets and configmaps should be used for environment variables in the capsule.
+
+_Appears in:_
+- [CapsuleSpec](#capsulespec)
+
+| Field | Description |
+| --- | --- |
+| `automatic` _boolean_ | Automatic sets wether the capsule should automatically use existing secrets and configmaps which share the same name as the capsule as environment variables. |
+| `from` _[EnvSource](#envsource) array_ | From holds a list of references to secrets and configmaps which should be mounted as environment variables. |
+
+
+#### EnvSource
+
+
+
+EnvSource holds a reference to either a ConfigMap or a Secret
+
+_Appears in:_
+- [Env](#env)
+
+| Field | Description |
+| --- | --- |
+| `configMapName` _string_ | ConfigMapName is the name of a ConfigMap in the same namespace as the Capsule |
+| `secretName` _string_ | SecretName is the name of a Secret in the same namespace as the Capsule |
+
+
+#### File
+
+
+
+File defines a mounted file and where to retrieve the contents from
+
+_Appears in:_
+- [CapsuleSpec](#capsulespec)
+
+| Field | Description |
+| --- | --- |
+| `path` _string_ |  |
+| `configMap` _[FileContentRef](#filecontentref)_ |  |
+| `secret` _[FileContentRef](#filecontentref)_ |  |
+
+
+#### FileContentRef
+
+
+
+FileContentRef defines the name of a config resource and the key from which to retrieve the contents
+
+_Appears in:_
+- [File](#file)
+
+| Field | Description |
+| --- | --- |
+| `name` _string_ |  |
+| `key` _string_ |  |
+
+
+#### HorizontalScale
+
+
+
+HorizontalScale defines the policy for the number of replicas of the capsule It can both be configured with autoscaling and with a static number of replicas
+
+_Appears in:_
+- [CapsuleSpec](#capsulespec)
+
+| Field | Description |
+| --- | --- |
+| `minReplicas` _integer_ |  |
+| `maxReplicas` _integer_ |  |
+| `cpuTarget` _[CPUTarget](#cputarget)_ |  |
+
+
+#### OwnedResource
+
+
+
+
+
+_Appears in:_
+- [CapsuleStatus](#capsulestatus)
+
+| Field | Description |
+| --- | --- |
+| `ref` _[TypedLocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#typedlocalobjectreference-v1-core)_ |  |
+| `state` _string_ |  |
+| `message` _string_ |  |
+
+
+
+

--- a/docs/docs/api/v1alpha2.md
+++ b/docs/docs/api/v1alpha2.md
@@ -1,0 +1,332 @@
+# API Reference
+
+## Packages
+- [rig.dev/v1alpha2](#rigdevv1alpha2)
+
+
+## rig.dev/v1alpha2
+
+Package v1alpha2 contains API Schema definitions for the v1alpha2 API group
+
+### Resource Types
+- [Capsule](#capsule)
+
+
+
+#### CPUTarget
+
+
+
+CPUTarget defines an autoscaler target for the CPU metric If empty, no autoscaling will be done
+
+_Appears in:_
+- [HorizontalScale](#horizontalscale)
+
+| Field | Description |
+| --- | --- |
+| `utilization` _integer_ |  |
+
+
+#### Capsule
+
+
+
+Capsule is the Schema for the capsules API
+
+
+
+| Field | Description |
+| --- | --- |
+| `apiVersion` _string_ | `rig.dev/v1alpha2`
+| `kind` _string_ | `Capsule`
+| `kind` _string_ | Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |
+| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `spec` _[CapsuleSpec](#capsulespec)_ |  |
+
+
+#### CapsuleInterface
+
+
+
+CapsuleInterface defines an interface for a capsule
+
+_Appears in:_
+- [CapsuleSpec](#capsulespec)
+
+| Field | Description |
+| --- | --- |
+| `name` _string_ |  |
+| `port` _integer_ |  |
+| `liveness` _[InterfaceProbe](#interfaceprobe)_ |  |
+| `readiness` _[InterfaceProbe](#interfaceprobe)_ |  |
+| `public` _[CapsulePublicInterface](#capsulepublicinterface)_ |  |
+
+
+#### CapsuleInterfaceIngress
+
+_Underlying type:_ _[struct{Host string "json:\"host\""}](#struct{host-string-"json:\"host\""})_
+
+CapsuleInterfaceIngress defines that the interface should be exposed as http ingress
+
+_Appears in:_
+- [CapsulePublicInterface](#capsulepublicinterface)
+
+
+
+#### CapsuleInterfaceLoadBalancer
+
+_Underlying type:_ _[struct{Port int32 "json:\"port\""}](#struct{port-int32-"json:\"port\""})_
+
+CapsuleInterfaceLoadBalancer defines that the interface should be exposed as a L4 loadbalancer
+
+_Appears in:_
+- [CapsulePublicInterface](#capsulepublicinterface)
+
+
+
+#### CapsulePublicInterface
+
+
+
+CapsulePublicInterface defines how to publicly expose the interface
+
+_Appears in:_
+- [CapsuleInterface](#capsuleinterface)
+
+| Field | Description |
+| --- | --- |
+| `ingress` _[CapsuleInterfaceIngress](#capsuleinterfaceingress)_ |  |
+| `loadBalancer` _[CapsuleInterfaceLoadBalancer](#capsuleinterfaceloadbalancer)_ |  |
+
+
+#### CapsuleScale
+
+
+
+
+
+_Appears in:_
+- [CapsuleSpec](#capsulespec)
+
+| Field | Description |
+| --- | --- |
+| `horizontal` _[HorizontalScale](#horizontalscale)_ |  |
+| `vertical` _[VerticalScale](#verticalscale)_ |  |
+
+
+#### CapsuleSpec
+
+
+
+CapsuleSpec defines the desired state of Capsule
+
+_Appears in:_
+- [Capsule](#capsule)
+
+| Field | Description |
+| --- | --- |
+| `image` _string_ |  |
+| `command` _string_ |  |
+| `args` _string array_ |  |
+| `interfaces` _[CapsuleInterface](#capsuleinterface) array_ |  |
+| `files` _[File](#file) array_ |  |
+| `scale` _[CapsuleScale](#capsulescale)_ |  |
+| `nodeSelector` _object (keys:string, values:string)_ |  |
+| `env` _[Env](#env)_ |  |
+
+
+#### DeploymentStatus
+
+
+
+
+
+_Appears in:_
+- [CapsuleStatus](#capsulestatus)
+
+| Field | Description |
+| --- | --- |
+| `state` _string_ |  |
+| `message` _string_ |  |
+
+
+#### Env
+
+
+
+Env defines what secrets and configmaps should be used for environment variables in the capsule.
+
+_Appears in:_
+- [CapsuleSpec](#capsulespec)
+
+| Field | Description |
+| --- | --- |
+| `disable_automatic` _boolean_ | DisableAutomatic sets wether the capsule should disable automatically use of existing secrets and configmaps which share the same name as the capsule as environment variables. |
+| `from` _[EnvReference](#envreference) array_ | From holds a list of references to secrets and configmaps which should be mounted as environment variables. |
+
+
+#### EnvReference
+
+
+
+EnvSource holds a reference to either a ConfigMap or a Secret
+
+_Appears in:_
+- [Env](#env)
+
+| Field | Description |
+| --- | --- |
+| `kind` _string_ | Kind is the resource kind of the env reference, must be ConfigMap or Secret. |
+| `name` _string_ | Name is the name of a ConfigMap or Secret in the same namespace as the Capsule. |
+
+
+#### File
+
+
+
+File defines a mounted file and where to retrieve the contents from
+
+_Appears in:_
+- [CapsuleSpec](#capsulespec)
+
+| Field | Description |
+| --- | --- |
+| `ref` _[FileContentReference](#filecontentreference)_ |  |
+| `path` _string_ |  |
+
+
+#### FileContentReference
+
+
+
+FileContentRef defines the name of a config resource and the key from which to retrieve the contents
+
+_Appears in:_
+- [File](#file)
+
+| Field | Description |
+| --- | --- |
+| `kind` _string_ |  |
+| `name` _string_ |  |
+| `key` _string_ |  |
+
+
+#### HorizontalScale
+
+
+
+HorizontalScale defines the policy for the number of replicas of the capsule It can both be configured with autoscaling and with a static number of replicas
+
+_Appears in:_
+- [CapsuleScale](#capsulescale)
+
+| Field | Description |
+| --- | --- |
+| `instances` _[Instances](#instances)_ |  |
+| `cpuTarget` _[CPUTarget](#cputarget)_ |  |
+
+
+#### Instances
+
+
+
+
+
+_Appears in:_
+- [HorizontalScale](#horizontalscale)
+
+| Field | Description |
+| --- | --- |
+| `min` _integer_ |  |
+| `max` _integer_ |  |
+
+
+#### InterfaceGRPCProbe
+
+_Underlying type:_ _[struct{Service string "json:\"service\""}](#struct{service-string-"json:\"service\""})_
+
+
+
+_Appears in:_
+- [InterfaceProbe](#interfaceprobe)
+
+
+
+#### InterfaceProbe
+
+
+
+
+
+_Appears in:_
+- [CapsuleInterface](#capsuleinterface)
+
+| Field | Description |
+| --- | --- |
+| `path` _string_ |  |
+| `tcp` _boolean_ |  |
+| `grpc` _[InterfaceGRPCProbe](#interfacegrpcprobe)_ |  |
+
+
+#### OwnedResource
+
+
+
+
+
+_Appears in:_
+- [CapsuleStatus](#capsulestatus)
+
+| Field | Description |
+| --- | --- |
+| `ref` _[TypedLocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#typedlocalobjectreference-v1-core)_ |  |
+| `state` _string_ |  |
+| `message` _string_ |  |
+
+
+#### ResourceLimits
+
+
+
+
+
+_Appears in:_
+- [VerticalScale](#verticalscale)
+
+| Field | Description |
+| --- | --- |
+| `request` _[Quantity](#quantity)_ |  |
+| `limit` _[Quantity](#quantity)_ |  |
+
+
+#### ResourceRequest
+
+
+
+
+
+_Appears in:_
+- [VerticalScale](#verticalscale)
+
+| Field | Description |
+| --- | --- |
+| `request` _[Quantity](#quantity)_ |  |
+
+
+#### VerticalScale
+
+
+
+
+
+_Appears in:_
+- [CapsuleScale](#capsulescale)
+
+| Field | Description |
+| --- | --- |
+| `cpu` _[ResourceLimits](#resourcelimits)_ |  |
+| `memory` _[ResourceLimits](#resourcelimits)_ |  |
+| `gpu` _[ResourceRequest](#resourcerequest)_ |  |
+
+

--- a/docs/menu.js
+++ b/docs/menu.js
@@ -288,6 +288,36 @@ const sidebars = {
       value: "Additional Resources",
       className: "homepage-sidebar-divider",
     },
+    {
+      type: "category",
+      label: "API Reference",
+      link: { type: "doc", id: "api" },
+      className: "homepage-sidebar-item",
+      customProps: {
+        sidebar_icon: "BiSolidFile",
+      },
+      collapsed: true,
+      items: [
+        {
+          type: "doc",
+          id: "api/config/v1alpha1",
+          label: "config.rig.dev/v1alpha1",
+          className: "docpage-sidebar-item",
+        },
+        {
+          type: "doc",
+          id: "api/v1alpha1",
+          label: "rig.dev/v1alpha1",
+          className: "docpage-sidebar-item",
+        },
+        {
+          type: "doc",
+          id: "api/v1alpha2",
+          label: "rig.dev/v1alpha2",
+          className: "docpage-sidebar-item",
+        },
+      ],
+    },
 
     {
       type: "doc",

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -21,6 +21,8 @@
   --docusaurus-tag-list-border: var(--ifm-color-emphasis-100);
   --ifm-toc-border-color: var(--ifm-color-emphasis-200);
   --docusaurus-highlighted-code-line-bg: rgb(72, 77, 91);
+
+  --ifm-table-cell-padding: 0.4rem;
 }
 
 .alert--info {
@@ -131,7 +133,6 @@ table {
   color: #687076;
   font-size: 13px;
   margin-left: 0px;
-  text-transform: capitalize;
 }
 
 .homepage-sidebar-category {

--- a/pkg/api/config/v1alpha1/groupversion_info.go
+++ b/pkg/api/config/v1alpha1/groupversion_info.go
@@ -1,5 +1,4 @@
 // Package v1alpha1 contains API Schema definitions for the config v1alpha1 API group
-// +kubebuilder:skip
 // +kubebuilder:object:generate=true
 // +groupName=config.rig.dev
 package v1alpha1

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/bufbuild/buf v1.14.0
 	github.com/bufbuild/connect-go v1.9.0
+	github.com/elastic/crd-ref-docs v0.0.10
 	github.com/golangci/golangci-lint v1.55.2
 	github.com/goreleaser/goreleaser v1.19.2
 	google.golang.org/protobuf v1.31.0
@@ -54,6 +55,7 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
+	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/OpenPeeDeeP/depguard/v2 v2.1.0 // indirect
@@ -181,6 +183,7 @@ require (
 	github.com/go-xmlfmt/xmlfmt v1.1.2 // indirect
 	github.com/gobuffalo/flect v1.0.2 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/goccy/go-yaml v1.11.0 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -753,6 +753,8 @@ github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0
 github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
+github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
+github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj9n6YA=
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
@@ -1283,6 +1285,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/edsrzf/mmap-go v1.1.0/go.mod h1:19H/e8pUPLicwkyNgOykDXkJ9F0MHE+Z52B8EIth78Q=
+github.com/elastic/crd-ref-docs v0.0.10 h1:FAc9oCxxY4+rMCLSLtTGrEaPyuxmp3LNlQ+dZfG9Ujc=
+github.com/elastic/crd-ref-docs v0.0.10/go.mod h1:zha4djxzWirfx+c4fl/Kmk9Rc7Fv7XBoOi9CL9kne+M=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20221015165544-a0805db90819 h1:RIB4cRk+lBqKK3Oy0r2gRX4ui7tuhiZq2SuTtTCi0/0=
 github.com/elliotchance/orderedmap/v2 v2.2.0 h1:7/2iwO98kYT4XkOjA9mBEIwvi4KpGB4cyHeOFOnj4Vk=
@@ -1361,6 +1365,7 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/fzipp/gocyclo v0.6.0 h1:lsblElZG7d3ALtGMx9fmxeTKZaLLpU8mET09yN4BBLo=
 github.com/fzipp/gocyclo v0.6.0/go.mod h1:rXPyn8fnlpa0R2csP/31uerbiVBugk5whMdlyaLkLoA=
+github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
@@ -1479,9 +1484,12 @@ github.com/go-pdf/fpdf v0.5.0/go.mod h1:HzcnA+A23uwogo0tp9yU+l3V+KXhiESpt1PMayhO
 github.com/go-pdf/fpdf v0.6.0/go.mod h1:HzcnA+A23uwogo0tp9yU+l3V+KXhiESpt1PMayhOh5M=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
+github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
+github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
+github.com/go-playground/validator/v10 v10.14.0 h1:vgvQWe3XCz3gIeFDm/HnTIbj6UGmg/+t63MyGU2n5js=
 github.com/go-resty/resty/v2 v2.1.1-0.20191201195748-d7b97669fe48/go.mod h1:dZGr0i9PLlaaTD4H/hoZIDjQ+r6xq8mgbRzHZf7f2J8=
 github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSMVIq3w7q0I=
 github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
@@ -1547,6 +1555,8 @@ github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6Wezm
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
 github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-yaml v1.9.5/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=
+github.com/goccy/go-yaml v1.11.0 h1:n7Z+zx8S9f9KgzG6KtQKf+kwqXZlLNR2F6018Dgau54=
+github.com/goccy/go-yaml v1.11.0/go.mod h1:H+mJrWtjPTJAHvRbV09MCK9xYwODM+wRTVFFTWckfng=
 github.com/godbus/dbus v0.0.0-20151105175453-c7fdd8b5cd55/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
@@ -2073,6 +2083,7 @@ github.com/ldez/gomoddirectives v0.2.3/go.mod h1:cpgBogWITnCfRq2qGoDkKMEVSaarhdB
 github.com/ldez/tagliatelle v0.5.0 h1:epgfuYt9v0CG3fms0pEgIMNPuFf/LpPIfjk4kyqSioo=
 github.com/ldez/tagliatelle v0.5.0/go.mod h1:rj1HmWiL1MiKQuOONhd09iySTEkUuE/8+5jtPYz9xa4=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
+github.com/leodido/go-urn v1.2.4 h1:XlAE/cm/ms7TE/VMVoduSpNBoyc2dOxHs5MZSwAN63Q=
 github.com/leonklingele/grouper v1.1.1 h1:suWXRU57D4/Enn6pXR0QVqqWWrnJ9Osrz+5rjt8ivzU=
 github.com/leonklingele/grouper v1.1.1/go.mod h1:uk3I3uDfi9B6PeUjsCKi6ndcf63Uy7snXgR4yDYQVDY=
 github.com/letsencrypt/boulder v0.0.0-20221109233200-85aa52084eaf h1:ndns1qx/5dL43g16EQkPV/i8+b3l5bYQwLeoSBe7tS8=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -3,6 +3,7 @@ package main
 import (
 	_ "github.com/bufbuild/buf/cmd/buf"
 	_ "github.com/bufbuild/connect-go/cmd/protoc-gen-connect-go"
+	_ "github.com/elastic/crd-ref-docs"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/goreleaser/goreleaser"
 	_ "google.golang.org/protobuf/cmd/protoc-gen-go"


### PR DESCRIPTION
Add automated API resource documentation. We use the crd-ref-gen project
to generate markdown based on the kubernetes resource types.

- ensure make gen generates docs
- remove kuberbuilder:skip from config api group and instead ensure that
  the maketarget only generates for our main api group.