### PR TITLE
👷 CI test improvements 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version-file: go.mod
           cache: false # this is handled in the golangci-lint-action
 
       - name: Cache tools
@@ -24,17 +24,16 @@ jobs:
         with:
           path: |
             tools/bin
-          key: ${{ runner.os }}-${{ github.job }}-tools-${{ hashFiles('tools/go.sum') }}
+          key: ${{ runner.os }}-tools-${{ hashFiles('tools/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-tools-
+            ${{ runner.os }}-tools-
 
       - name: Generate code
-        run: make gen
+        run: make ci
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.55.2
           args: --timeout 3m
 
   test:
@@ -45,19 +44,19 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.0
+          go-version-file: go.mod
 
       - name: Cache tools
         uses: actions/cache@v3
         with:
           path: |
             tools/bin
-          key: ${{ runner.os }}-${{ github.job }}-tools-${{ hashFiles('tools/go.sum') }}
+          key: ${{ runner.os }}-tools-${{ hashFiles('tools/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-${{ github.job }}-tools-
+            ${{ runner.os }}-tools-
 
       - name: Run tests
-        run: make gen build test-all
+        run: make ci test-all
 
       - name: Test Summary
         uses: test-summary/action@v2
@@ -72,7 +71,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.0
+          go-version: '1.21'
 
       - name: Test cli import
         run: |
@@ -81,3 +80,34 @@ jobs:
           echo -e 'package main\nimport (\n	_ "github.com/rigdev/rig/cmd/rig/cmd"\n)\nfunc main() {\n}\n' > main.go
           go mod tidy
           go run ./main.go
+
+  generated-files-committed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+
+      - name: Cache tools
+        uses: actions/cache@v3
+        with:
+          path: |
+            tools/bin
+          key: ${{ runner.os }}-tools-${{ hashFiles('tools/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-tools-
+
+      - name: Check for uncommitted changes after generating files
+        run: |
+          make ci
+          go mod tidy
+          cd tools && go mod tidy
+          GIT_STATUS="$(git status --porcelain)"
+          if [ -n "$GIT_STATUS" ]; then
+            echo "Repository has uncommited files:"
+            echo "$GIT_STATUS"
+            exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -185,17 +185,17 @@ release: goreleaser ## 🔖 Release project
 release-build: goreleaser ## 📸 Build release snapshot
 	$(GORELEASER) build -f ./build/package/goreleaser/goreleaser.yml --snapshot --clean
 
+##@ Release CI
+
+.PHONY: ci
+ci: gen setup-envtest gotestsum golangci-lint goreleaser ## Ensure tools are installed, go modules are downloaded and build cache is populated.
+	go build ./...
+
 ##@ Binaries
 
 TOOLSBIN ?= $(shell pwd)/tools/bin
 $(TOOLSBIN):
 	mkdir -p $(TOOLSBIN)
-
-.PHONY: tools
-tools: buf protoc-gen-go protoc-gen-connect-go goreleaser kind gotestsum ## 📦 Download all tools
-
-.PHONY: tools-ci
-tools-ci: buf protoc-gen-go protoc-gen-connect-go goreleaser gotestsum controller-gen setup-envtest ## 📦 Download tools used in CI
 
 BUF ?= $(TOOLSBIN)/buf
 BUF_GO_MOD_VERSION ?= $(shell cat tools/go.mod | grep -E "github.com/bufbuild/buf " | cut -d ' ' -f2 | cut -c2-)

--- a/docs/docs/api/v1alpha2.md
+++ b/docs/docs/api/v1alpha2.md
@@ -39,8 +39,6 @@ Capsule is the Schema for the capsules API
 | --- | --- |
 | `apiVersion` _string_ | `rig.dev/v1alpha2`
 | `kind` _string_ | `Capsule`
-| `kind` _string_ | Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds |
-| `apiVersion` _string_ | APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources |
 | `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
 | `spec` _[CapsuleSpec](#capsulespec)_ |  |
 

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,6 @@ require (
 require (
 	cloud.google.com/go/firestore v1.11.0 // indirect
 	cloud.google.com/go/longrunning v0.5.1 // indirect
-	dario.cat/mergo v1.0.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/alessio/shellescape v1.4.1 // indirect
@@ -108,7 +107,7 @@ require (
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.5 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
-	github.com/imdario/mergo v0.3.16 // indirect
+	github.com/imdario/mergo v0.3.16
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,6 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 cloud.google.com/go/storage v1.30.1 h1:uOdMxAs8HExqBlnLtnQyP0YkvbiDpdGShGKtx6U/oNM=
 cloud.google.com/go/storage v1.30.1/go.mod h1:NfxhC0UJE1aXSx7CIIbCf7y9HKT7BiccwkR7+P7gN8E=
-dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
-dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 firebase.google.com/go v3.13.0+incompatible h1:3TdYC3DDi6aHn20qoRkxwGqNgdjtblwVAyRLQwGn/+4=
 firebase.google.com/go v3.13.0+incompatible/go.mod h1:xlah6XbEyW6tbfSklcfe5FHJIwjt8toICdV5Wh9ptHs=


### PR DESCRIPTION
- Add check to ensure that all generated files are committed. This
  includes checking that the go modules are tidied using `go mod tidy`.
  Fixes https://github.com/rigdev/rig/issues/322
- Create ci make targe
- Ensure all test jobs use the ci make target in order to share
  the same cache of installed tools, go packages and go build cache.
- Use go version from go.mod