### PR TITLE
:bug: Ensure that command and args are set

### DIFF
--- a/pkg/controller/capsule_controller.go
+++ b/pkg/controller/capsule_controller.go
@@ -860,6 +860,11 @@ func createDeployment(
 		VolumeMounts: volumeMounts,
 		Ports:        ports,
 		Resources:    makeResourceRequirements(capsule),
+		Args:         capsule.Spec.Args,
+	}
+
+	if capsule.Spec.Command != "" {
+		c.Command = []string{capsule.Spec.Command}
 	}
 
 	for _, i := range capsule.Spec.Interfaces {


### PR DESCRIPTION
For some reason we didn't pass Command or Args to the underlying
Deployment resource, which means that we always would run the entrypoint
of the docker container instead of what was set in Command or Args.
