### PR TITLE
✨ Add pathPrefix option for ingress interface

### DIFF
--- a/deploy/charts/rig-operator/Chart.yaml
+++ b/deploy/charts/rig-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.22
+version: 0.1.23
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/rig-operator/templates/crd.yaml
+++ b/deploy/charts/rig-operator/templates/crd.yaml
@@ -217,6 +217,10 @@ spec:
                               description: Host specifies the DNS name of the Ingress
                                 resource
                               type: string
+                            pathPrefix:
+                              description: PathPrefix specifies a path prefix which
+                                requests should match in order to hit this ingress.
+                              type: string
                           required:
                           - host
                           type: object

--- a/docs/docs/api/v1alpha2.md
+++ b/docs/docs/api/v1alpha2.md
@@ -62,7 +62,7 @@ _Appears in:_
 
 ### CapsuleInterfaceIngress
 
-_Underlying type:_ _[struct{Host string "json:\"host\""}](#struct{host-string-"json:\"host\""})_
+_Underlying type:_ _[struct{Host string "json:\"host\""; PathPrefix string "json:\"pathPrefix,omitempty\""}](#struct{host-string-"json:\"host\"";-pathprefix-string-"json:\"pathprefix,omitempty\""})_
 
 CapsuleInterfaceIngress defines that the interface should be exposed as http ingress
 

--- a/pkg/api/v1alpha2/capsule_types.go
+++ b/pkg/api/v1alpha2/capsule_types.go
@@ -265,8 +265,12 @@ type CapsulePublicInterface struct {
 // CapsuleInterfaceIngress defines that the interface should be exposed as http
 // ingress
 type CapsuleInterfaceIngress struct {
-	// Host specifies the DNS name of the Ingress resource
+	// Host specifies the DNS name of the Ingress resource.
 	Host string `json:"host"`
+
+	// PathPrefix specifies a path prefix which requests should match in order
+	// to hit this ingress.
+	PathPrefix string `json:"pathPrefix,omitempty"`
 }
 
 // CapsuleInterfaceLoadBalancer defines that the interface should be exposed as

--- a/pkg/controller/capsule_controller.go
+++ b/pkg/controller/capsule_controller.go
@@ -1310,6 +1310,9 @@ func (r *CapsuleReconciler) createIngress(
 					},
 				},
 			})
+			if inf.Public.Ingress.PathPrefix != "" {
+				ing.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Path = inf.Public.Ingress.PathPrefix
+			}
 			if len(ing.Spec.TLS) == 0 {
 				ing.Spec.TLS = []netv1.IngressTLS{{
 					SecretName: fmt.Sprintf("%s-tls", capsule.Name),

--- a/test/integration/k8s/capsule_controller_test.go
+++ b/test/integration/k8s/capsule_controller_test.go
@@ -405,7 +405,8 @@ func (s *K8sTestSuite) TestController() {
 
 	capsule.Spec.Interfaces[0].Public = &v1alpha2.CapsulePublicInterface{
 		Ingress: &v1alpha2.CapsuleInterfaceIngress{
-			Host: "test.com",
+			Host:       "test.com",
+			PathPrefix: "/test",
 		},
 	}
 	assert.NoError(t, k8sClient.Update(ctx, &capsule))
@@ -426,7 +427,7 @@ func (s *K8sTestSuite) TestController() {
 					IngressRuleValue: netv1.IngressRuleValue{
 						HTTP: &netv1.HTTPIngressRuleValue{
 							Paths: []netv1.HTTPIngressPath{{
-								Path:     "/",
+								Path:     "/test",
 								PathType: &pt,
 								Backend: netv1.IngressBackend{
 									Service: &netv1.IngressServiceBackend{


### PR DESCRIPTION
This enables matching requests against a path prefix, which will be
required in order to hit the ingress.
