### PR TITLE
:children_crossing: Make it easier to remove mounted files from the CLI

### DIFF
--- a/cmd/rig/cmd/capsule/mount/remove.go
+++ b/cmd/rig/cmd/capsule/mount/remove.go
@@ -2,6 +2,8 @@ package mount
 
 import (
 	"context"
+	"fmt"
+	"slices"
 
 	"github.com/bufbuild/connect-go"
 	"github.com/rigdev/rig-go-api/api/v1/capsule"
@@ -16,7 +18,22 @@ func (c *Cmd) remove(ctx context.Context, _ *cobra.Command, args []string) error
 	var path string
 	var err error
 	if len(args) != 1 {
-		path, err = common.PromptInput("mount path:", common.ValidateAbsPathOpt)
+		rollout, err := capsule_cmd.GetCurrentRollout(ctx, c.Rig, c.Cfg)
+		if err != nil {
+			return err
+		}
+		var paths []string
+		for _, path := range rollout.GetConfig().GetConfigFiles() {
+			paths = append(paths, path.GetPath())
+		}
+
+		slices.Sort(paths)
+		if len(paths) == 0 {
+			fmt.Println("Capsule has no mounted files")
+			return nil
+		}
+
+		_, path, err = common.PromptSelect("Mount path:", paths)
 		if err != nil {
 			return err
 		}

--- a/cmd/rig/cmd/capsule/mount/set.go
+++ b/cmd/rig/cmd/capsule/mount/set.go
@@ -27,8 +27,17 @@ func (c *Cmd) set(ctx context.Context, _ *cobra.Command, _ []string) error {
 		return err
 	}
 
+	rollout, err := capsule_cmd.GetCurrentRollout(ctx, c.Rig, c.Cfg)
+	if err != nil {
+		return err
+	}
+
+	var paths []string
+	for _, p := range rollout.GetConfig().GetConfigFiles() {
+		paths = append(paths, p.GetPath())
+	}
 	if dstPath == "" {
-		dstPath, err = common.PromptInput("Destination path", common.ValidateAbsPathOpt)
+		dstPath, err = common.PromptInput("Destination path", common.ValidateAbsPathOpt, common.ValidateUniqueOpt(paths))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The CLI now prompts you to select a path from the existing files when
removing.
