### PR TITLE
:bug: Fix CLI bug with 'rig config init'

### DIFF
--- a/cmd/rig/cmd/base/common.go
+++ b/cmd/rig/cmd/base/common.go
@@ -12,6 +12,10 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
+type PromptInformation struct {
+	ContextCreation bool
+}
+
 const (
 	RFC3339NanoFixed  = "2006-01-02T15:04:05.000000000Z07:00"
 	RFC3339MilliFixed = "2006-01-02T15:04:05.000Z07:00"

--- a/cmd/rig/cmd/base/register.go
+++ b/cmd/rig/cmd/base/register.go
@@ -32,9 +32,10 @@ var Module = fx.Module(
 			client.WithAPIVersionNegotiation(),
 		)
 	}),
+	fx.Provide(func() *PromptInformation { return &PromptInformation{} }),
 )
 
-func getContext(cfg *cmdconfig.Config) (*cmdconfig.Context, error) {
+func getContext(cfg *cmdconfig.Config, promptInfo *PromptInformation) (*cmdconfig.Context, error) {
 	if cfg.CurrentContextName == "" {
 		if len(cfg.Contexts) > 0 {
 			fmt.Println("No context selected, please select one")
@@ -42,6 +43,7 @@ func getContext(cfg *cmdconfig.Config) (*cmdconfig.Context, error) {
 				return nil, err
 			}
 		} else {
+			promptInfo.ContextCreation = true
 			fmt.Println("No context available, please create one")
 			if err := cmdconfig.CreateDefaultContext(cfg); err != nil {
 				return nil, err
@@ -51,6 +53,7 @@ func getContext(cfg *cmdconfig.Config) (*cmdconfig.Context, error) {
 
 	c := cfg.GetCurrentContext()
 	if c == nil {
+		// This shouldn't happen as we prompt for a config if one is missing above
 		return nil, fmt.Errorf("no current context in config, run `rig config init`")
 	}
 

--- a/cmd/rig/cmd/config/init.go
+++ b/cmd/rig/cmd/config/init.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (c *Cmd) init(_ *cobra.Command, _ []string) error {
+	if c.PromptInfo.ContextCreation {
+		return nil
+	}
+
 	if ok, err := common.PromptConfirm("Do you want to configure a new context?", true); err != nil {
 		return err
 	} else if !ok {

--- a/cmd/rig/cmd/config/setup.go
+++ b/cmd/rig/cmd/config/setup.go
@@ -14,8 +14,9 @@ import (
 type Cmd struct {
 	fx.In
 
-	Rig rig.Client
-	Cfg *cmdconfig.Config
+	Rig        rig.Client
+	Cfg        *cmdconfig.Config
+	PromptInfo *base.PromptInformation
 }
 
 var cmd Cmd
@@ -23,6 +24,7 @@ var cmd Cmd
 func initCmd(c Cmd) {
 	cmd.Rig = c.Rig
 	cmd.Cfg = c.Cfg
+	cmd.PromptInfo = c.PromptInfo
 }
 
 func Setup(parent *cobra.Command) {


### PR DESCRIPTION
If you had no context, it would prompt to make a context twice.
