### PR TITLE
:bug: Fix CLI bug where it couldn't start if the context had an unknown user

### DIFF
--- a/cmd/rig/cmd/base/auth.go
+++ b/cmd/rig/cmd/base/auth.go
@@ -69,20 +69,6 @@ func CheckAuth(ctx context.Context, cmd *cobra.Command, rc rig.Client, cfg *cmdc
 	}
 }
 
-// type authFunc func(ctx context.Context, cmd *cobra.Command, rc rig.Client, cfg *cmdconfig.Config, interactive bool) error
-
-// func retryOnAuthErr(f authFunc, ctx context.Context, cmd *cobra.Command, rc rig.Client, cfg *cmdconfig.Config, interactive bool) error {
-// 	for {
-// 		err := f(ctx, cmd, rc, cfg, interactive)
-// 		if err == nil {
-// 			return nil
-// 		}
-// 		if err := handleAuthError(cfg, err, interactive); err != nil {
-// 			return err
-// 		}
-// 	}
-// }
-
 func handleAuthError(cfg *cmdconfig.Config, origErr error, interactive bool) (bool, error) {
 	if !errors.IsUnauthenticated(origErr) {
 		return false, origErr

--- a/cmd/rig/cmd/base/auth.go
+++ b/cmd/rig/cmd/base/auth.go
@@ -32,24 +32,82 @@ func CheckAuth(ctx context.Context, cmd *cobra.Command, rc rig.Client, cfg *cmdc
 
 	annotations := GetAllAnnotations(cmd)
 
-	if _, ok := annotations[OmitUser]; !ok {
-		if err := authUser(ctx, rc, cfg, interactive); err != nil {
-			return err
+	for {
+		if _, ok := annotations[OmitUser]; !ok {
+			err := authUser(ctx, cmd, rc, cfg, interactive)
+			retry, err := handleAuthError(cfg, err, interactive)
+			if err != nil {
+				return err
+			}
+			if retry {
+				continue
+			}
 		}
+
+		if _, ok := annotations[OmitProject]; !ok {
+			err := authProject(ctx, cmd, rc, cfg, interactive)
+			retry, err := handleAuthError(cfg, err, interactive)
+			if err != nil {
+				return err
+			}
+			if retry {
+				continue
+			}
+		}
+		if _, ok := annotations[OmitEnvironment]; !ok {
+			err := authEnvironment(ctx, cmd, rc, cfg, interactive)
+			retry, err := handleAuthError(cfg, err, interactive)
+			if err != nil {
+				return err
+			}
+			if retry {
+				continue
+			}
+		}
+
+		return nil
+	}
+}
+
+// type authFunc func(ctx context.Context, cmd *cobra.Command, rc rig.Client, cfg *cmdconfig.Config, interactive bool) error
+
+// func retryOnAuthErr(f authFunc, ctx context.Context, cmd *cobra.Command, rc rig.Client, cfg *cmdconfig.Config, interactive bool) error {
+// 	for {
+// 		err := f(ctx, cmd, rc, cfg, interactive)
+// 		if err == nil {
+// 			return nil
+// 		}
+// 		if err := handleAuthError(cfg, err, interactive); err != nil {
+// 			return err
+// 		}
+// 	}
+// }
+
+func handleAuthError(cfg *cmdconfig.Config, origErr error, interactive bool) (bool, error) {
+	if !errors.IsUnauthenticated(origErr) {
+		return false, origErr
 	}
 
-	if _, ok := annotations[OmitProject]; !ok {
-		if err := authProject(ctx, cmd, rc, cfg, interactive); err != nil {
-			return err
-		}
+	cmdContext := cfg.GetCurrentContext()
+	s := fmt.Sprintf("There seems to be an issue with the authentication information stored in your current context '%s'", cmdContext.Name)
+	if !interactive {
+		return false, fmt.Errorf("%s: %s", s, origErr)
 	}
-	if _, ok := annotations[OmitEnvironment]; !ok {
-		if err := authEnvironment(ctx, cmd, rc, cfg, interactive); err != nil {
-			return err
-		}
+	fmt.Println(s)
+	ok, err := common.PromptConfirm("Do you wish to rebuild this context before proceeding?", true)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, origErr
 	}
 
-	return nil
+	cfg.DeleteContext(cmdContext.Name)
+	if err := cfg.CreateContext(cmdContext.Name, cmdContext.GetService().Server); err != nil {
+		return false, err
+	}
+
+	return true, nil
 }
 
 func authEnvironment(ctx context.Context,
@@ -121,7 +179,7 @@ func authEnvironment(ctx context.Context,
 	return nil
 }
 
-func authUser(ctx context.Context, rig rig.Client, cfg *cmdconfig.Config, interactive bool) error {
+func authUser(ctx context.Context, cmd *cobra.Command, rig rig.Client, cfg *cmdconfig.Config, interactive bool) error {
 	user := cfg.GetCurrentAuth().UserID
 	if !uuid.UUID(user).IsNil() && user != "" {
 		return nil

--- a/cmd/rig/cmd/base/auth.go
+++ b/cmd/rig/cmd/base/auth.go
@@ -75,7 +75,10 @@ func handleAuthError(cfg *cmdconfig.Config, origErr error, interactive bool) (bo
 	}
 
 	cmdContext := cfg.GetCurrentContext()
-	s := fmt.Sprintf("There seems to be an issue with the authentication information stored in your current context '%s'", cmdContext.Name)
+	s := fmt.Sprintf(
+		"There seems to be an issue with the authentication information stored in your current context '%s'",
+		cmdContext.Name,
+	)
 	if !interactive {
 		return false, fmt.Errorf("%s: %s", s, origErr)
 	}
@@ -165,7 +168,7 @@ func authEnvironment(ctx context.Context,
 	return nil
 }
 
-func authUser(ctx context.Context, cmd *cobra.Command, rig rig.Client, cfg *cmdconfig.Config, interactive bool) error {
+func authUser(ctx context.Context, _ *cobra.Command, rig rig.Client, cfg *cmdconfig.Config, interactive bool) error {
 	user := cfg.GetCurrentAuth().UserID
 	if !uuid.UUID(user).IsNil() && user != "" {
 		return nil

--- a/cmd/rig/cmd/base/register.go
+++ b/cmd/rig/cmd/base/register.go
@@ -52,13 +52,13 @@ func getContext(cfg *cmdconfig.Config, promptInfo *PromptInformation) (*cmdconfi
 	if cfg.CurrentContextName == "" {
 		if len(cfg.Contexts) > 0 {
 			fmt.Println("No context selected, please select one")
-			if err := cmdconfig.SelectContext(cfg); err != nil {
+			if err := cfg.SelectContext(); err != nil {
 				return nil, err
 			}
 		} else {
 			promptInfo.ContextCreation = true
 			fmt.Println("No context available, please create one")
-			if err := cmdconfig.CreateDefaultContext(cfg); err != nil {
+			if err := cfg.CreateDefaultContext(); err != nil {
 				return nil, err
 			}
 		}

--- a/cmd/rig/cmd/cmdconfig/config.go
+++ b/cmd/rig/cmd/cmdconfig/config.go
@@ -117,6 +117,30 @@ func (cfg *Config) GetCurrentService() *Service {
 	return nil
 }
 
+func (cfg *Config) DeleteContext(name string) bool {
+	found := false
+	for idx, c := range cfg.Contexts {
+		if c.Name == name {
+			cfg.Contexts = append(cfg.Contexts[:idx], cfg.Contexts[idx+1:]...)
+			found = true
+		}
+	}
+
+	for idx, s := range cfg.Services {
+		if s.Name == name {
+			cfg.Services = append(cfg.Services[:idx], cfg.Services[idx+1:]...)
+		}
+	}
+
+	for idx, u := range cfg.Users {
+		if u.Name == name {
+			cfg.Users = append(cfg.Users[:idx], cfg.Users[idx+1:]...)
+		}
+	}
+
+	return found
+}
+
 func (cfg Config) Save() error {
 	bs, err := yaml.Marshal(cfg)
 	if err != nil {

--- a/cmd/rig/cmd/cmdconfig/context.go
+++ b/cmd/rig/cmd/cmdconfig/context.go
@@ -7,7 +7,7 @@ import (
 	"github.com/rigdev/rig/pkg/uuid"
 )
 
-func UseContext(cfg *Config, name string) error {
+func (cfg *Config) UseContext(name string) error {
 	for _, c := range cfg.Contexts {
 		if c.Name == name {
 			cfg.CurrentContextName = c.Name
@@ -18,7 +18,7 @@ func UseContext(cfg *Config, name string) error {
 	return fmt.Errorf("unknown context '%v'", name)
 }
 
-func SelectContext(cfg *Config) error {
+func (cfg *Config) SelectContext() error {
 	var labels []string
 	for _, c := range cfg.Contexts {
 		if c.Name == cfg.CurrentContextName {
@@ -37,11 +37,11 @@ func SelectContext(cfg *Config) error {
 	return cfg.Save()
 }
 
-func CreateDefaultContext(cfg *Config) error {
-	return CreateContext(cfg, "local", "http://localhost:4747/")
+func (cfg *Config) CreateDefaultContext() error {
+	return cfg.CreateContext("local", "http://localhost:4747/")
 }
 
-func CreateContext(cfg *Config, name, url string) error {
+func (cfg *Config) CreateContext(name, url string) error {
 	name, err := common.PromptInput("Name:", common.ValidateSystemNameOpt, common.InputDefaultOpt(name))
 	if err != nil {
 		return err
@@ -99,14 +99,4 @@ func CreateContext(cfg *Config, name, url string) error {
 	}
 
 	return cfg.Save()
-}
-
-func ConfigInit(cfg *Config) error {
-	if ok, err := common.PromptConfirm("Do you want to configure a new Rig context?", true); err != nil {
-		return err
-	} else if !ok {
-		return nil
-	}
-
-	return CreateDefaultContext(cfg)
 }

--- a/cmd/rig/cmd/config/init.go
+++ b/cmd/rig/cmd/config/init.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/rigdev/rig/cmd/common"
-	"github.com/rigdev/rig/cmd/rig/cmd/cmdconfig"
 	"github.com/spf13/cobra"
 )
 
@@ -19,5 +18,5 @@ func (c *Cmd) init(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("aborted")
 	}
 
-	return cmdconfig.CreateDefaultContext(c.Cfg)
+	return c.Cfg.CreateDefaultContext()
 }

--- a/cmd/rig/cmd/config/use_context.go
+++ b/cmd/rig/cmd/config/use_context.go
@@ -1,14 +1,12 @@
 package config
 
 import (
-	"github.com/rigdev/rig/cmd/rig/cmd/cmdconfig"
 	"github.com/spf13/cobra"
 )
 
 func (c *Cmd) useContext(_ *cobra.Command, args []string) error {
 	if len(args) > 0 {
-		return cmdconfig.UseContext(c.Cfg, args[0])
+		return c.Cfg.UseContext(args[0])
 	}
-
-	return cmdconfig.SelectContext(c.Cfg)
+	return c.Cfg.SelectContext()
 }


### PR DESCRIPTION
If the current Rig context referenced a user which no longer existed, the CLI
would fail with an unhelpful error message.
We now inform that the context is probably broken and prompt for rebuilding
it.
