### PR TITLE
:boom: Change CapsuleMetrics to accept a timestamp instead of pagination

### DIFF
--- a/docs/docs/api/platform-api.md
+++ b/docs/docs/api/platform-api.md
@@ -3657,9 +3657,9 @@ Request for getting metrics for a capsule and optionally a single instance.
 | ----- | ---- | ----- | ----------- |
 | capsule_id | [string](#string) |  | The capsule to get metrics for. |
 | instance_id | [string](#string) |  | If set, only returns metrics for the given instance_id. |
-| pagination | [model.Pagination](#model-Pagination) |  | Pagination options. |
 | project_id | [string](#string) |  | The project in which the capsule lives. |
 | environment_id | [string](#string) |  | The environment to get metrics for. |
+| since | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | Return metrics generated after 'since' |
 
 
 

--- a/proto/rig/api/v1/capsule/service.proto
+++ b/proto/rig/api/v1/capsule/service.proto
@@ -322,9 +322,9 @@ message ListEventsResponse {
 message CapsuleMetricsRequest {
   string capsule_id = 1; // The capsule to get metrics for.
   string instance_id = 2; // If set, only returns metrics for the given instance_id.
-  model.Pagination pagination = 3; // Pagination options.
   string project_id = 4; // The project in which the capsule lives.
   string environment_id = 5; // The environment to get metrics for.
+  google.protobuf.Timestamp since = 6; // Return metrics generated after 'since'
 }
 
 


### PR DESCRIPTION
The endpoint returns values for each instance of the capsule. Thus if you
use a pagination with a fixed limit, the time window of the metrics
depends on the number of instances the capsule has.
