### PR TITLE
🩺 Add health check for webhooks

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/rigdev/rig/pkg/api/v1alpha1"
@@ -74,6 +75,13 @@ func New(
 			return nil, err
 		}
 		//+kubebuilder:scaffold:builder
+
+		if err := mgr.AddHealthzCheck("webhooks", mgr.GetWebhookServer().StartedChecker()); err != nil {
+			return nil, fmt.Errorf("could not add webhooks healthz check: %w", err)
+		}
+		if err := mgr.AddReadyzCheck("webhooks", mgr.GetWebhookServer().StartedChecker()); err != nil {
+			return nil, fmt.Errorf("could not add webhooks readyz check: %w", err)
+		}
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {


### PR DESCRIPTION
Sometimes when scripting quick installation of the rig-operator and
resources depending on the Capsule API, you would get an error because
the validation webhooks were not ready yet.

Including the webhooks' ready state in the healthcheck enables us to
`helm install --wait` which will block until the healthchecks passes.
