### PR TITLE
:bug: Fix merging of runtime.Object

### DIFF
--- a/pkg/controller/cron_jobs_step.go
+++ b/pkg/controller/cron_jobs_step.go
@@ -82,6 +82,10 @@ func (s *CronJobStep) createCronJobs(req pipeline.CapsuleRequest) ([]*batchv1.Cr
 		maps.Copy(annotations, req.Capsule().Annotations)
 
 		j := &batchv1.CronJob{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "batch/v1",
+				APIVersion: "CronJob",
+			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("%s-%s", req.Capsule().Name, job.Name),
 				Namespace: req.Capsule().Namespace,

--- a/pkg/controller/deployment_step.go
+++ b/pkg/controller/deployment_step.go
@@ -218,6 +218,10 @@ func (s *DeploymentStep) createDeployment(
 		}
 	}
 	d := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      req.Capsule().Name,
 			Namespace: req.Capsule().Namespace,

--- a/pkg/controller/network_step.go
+++ b/pkg/controller/network_step.go
@@ -134,6 +134,10 @@ func (s *NetworkStep) createService(req pipeline.CapsuleRequest) *corev1.Service
 
 func (s *NetworkStep) createCertificate(req pipeline.CapsuleRequest) *cmv1.Certificate {
 	crt := &cmv1.Certificate{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Certificate",
+			APIVersion: "cert-manager.io/v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      req.Capsule().Name,
 			Namespace: req.Capsule().Namespace,
@@ -161,6 +165,10 @@ func (s *NetworkStep) createCertificate(req pipeline.CapsuleRequest) *cmv1.Certi
 
 func (s *NetworkStep) createIngress(req pipeline.CapsuleRequest) *netv1.Ingress {
 	ing := &netv1.Ingress{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Ingress",
+			APIVersion: "networking.k8s.io/v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        req.Capsule().Name,
 			Namespace:   req.Capsule().Namespace,
@@ -242,6 +250,9 @@ func (s *NetworkStep) createIngress(req pipeline.CapsuleRequest) *netv1.Ingress 
 
 func (s *NetworkStep) createLoadBalancer(req pipeline.CapsuleRequest) *v1.Service {
 	svc := &v1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Service",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-lb", req.Capsule().Name),
 			Namespace: req.Capsule().Namespace,

--- a/pkg/controller/pipeline/capsule_request.go
+++ b/pkg/controller/pipeline/capsule_request.go
@@ -42,14 +42,14 @@ type capsuleRequest struct {
 	logger             logr.Logger
 }
 
-func newCapsuleRequest(p *Pipeline, capsule *v1alpha2.Capsule) *capsuleRequest {
+func NewCapsuleRequest(p *Pipeline, capsule *v1alpha2.Capsule) *capsuleRequest {
 	r := &capsuleRequest{
-		pipeline: p,
-		logger: p.logger.WithValues(
-			"capsule", capsule.Name,
-		),
+		pipeline:       p,
 		capsule:        capsule,
 		currentObjects: map[objectKey]client.Object{},
+		objects:        map[objectKey]*Object{},
+		usedResources:  []v1alpha2.UsedResource{},
+		logger:         p.logger.WithValues("capsule", capsule.Name),
 	}
 
 	if capsule.Status != nil {

--- a/pkg/controller/pipeline/pipeline.go
+++ b/pkg/controller/pipeline/pipeline.go
@@ -52,6 +52,7 @@ type Pipeline struct {
 	client client.Client
 	config *configv1alpha1.OperatorConfig
 	scheme *runtime.Scheme
+	// TODO Use zap instead
 	logger logr.Logger
 	steps  []Step
 }
@@ -77,7 +78,7 @@ func (p *Pipeline) AddStep(step Step) {
 }
 
 func (p *Pipeline) RunCapsule(ctx context.Context, capsule *v1alpha2.Capsule, dryRun bool) (*Result, error) {
-	req := newCapsuleRequest(p, capsule)
+	req := NewCapsuleRequest(p, capsule)
 
 	result, err := p.runSteps(ctx, req, dryRun)
 	if errors.IsFailedPrecondition(err) {

--- a/pkg/controller/plugin/objectTemplate/main.go
+++ b/pkg/controller/plugin/objectTemplate/main.go
@@ -93,7 +93,7 @@ func (p *objectTemplatePlugin) Run(_ context.Context, req pipeline.CapsuleReques
 	var currentBytes bytes.Buffer
 	serializer := obj.NewSerializer(req.Scheme())
 	if err := serializer.Encode(currentObject, &currentBytes); err != nil {
-		return fmt.Errorf("could not encode current obj: %w", err)
+		return err
 	}
 
 	modifiedBytes, err := strategicpatch.StrategicMergePatch(currentBytes.Bytes(), patchBytes, currentObject)

--- a/pkg/controller/plugin/objectTemplate/main.go
+++ b/pkg/controller/plugin/objectTemplate/main.go
@@ -12,7 +12,9 @@ import (
 	"github.com/rigdev/rig/pkg/errors"
 	"github.com/rigdev/rig/pkg/obj"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 )
 
 type Config struct {
@@ -45,10 +47,10 @@ func (p *objectTemplatePlugin) Run(_ context.Context, req pipeline.CapsuleReques
 		return err
 	}
 
-	cc := co.(client.Object)
-	cc.SetName(p.config.Name)
+	currentObject := co.(client.Object)
+	currentObject.SetName(p.config.Name)
 
-	if err := req.GetNew(cc); errors.IsNotFound(err) {
+	if err := req.GetNew(currentObject); errors.IsNotFound(err) {
 		return nil
 	} else if err != nil {
 		return err
@@ -61,7 +63,7 @@ func (p *objectTemplatePlugin) Run(_ context.Context, req pipeline.CapsuleReques
 
 	input := map[string]interface{}{
 		"capsule": req.Capsule(),
-		"current": cc,
+		"current": currentObject,
 	}
 
 	values := map[string]interface{}{}
@@ -79,26 +81,31 @@ func (p *objectTemplatePlugin) Run(_ context.Context, req pipeline.CapsuleReques
 		values[name] = result
 	}
 
-	var out bytes.Buffer
-	if err := t.Execute(&out, values); err != nil {
+	var patchBuffer bytes.Buffer
+	if err := t.Execute(&patchBuffer, values); err != nil {
 		return err
 	}
-
-	patch, err := req.Scheme().New(gvk)
+	patchBytes, err := yaml.YAMLToJSON(patchBuffer.Bytes())
 	if err != nil {
 		return err
 	}
 
-	if err := obj.DecodeInto(out.Bytes(), patch, req.Scheme()); err != nil {
+	var currentBytes bytes.Buffer
+	serializer := obj.NewSerializer(req.Scheme())
+	if err := serializer.Encode(currentObject, &currentBytes); err != nil {
+		return fmt.Errorf("could not encode current obj: %w", err)
+	}
+
+	modifiedBytes, err := strategicpatch.StrategicMergePatch(currentBytes.Bytes(), patchBytes, currentObject)
+	if err != nil {
 		return err
 	}
 
-	merge := obj.NewMerger(req.Scheme())
-	if err := merge.Merge(patch, cc); err != nil {
+	if err := obj.DecodeInto(modifiedBytes, currentObject, req.Scheme()); err != nil {
 		return err
 	}
 
-	return req.Set(cc)
+	return req.Set(currentObject)
 }
 
 func main() {

--- a/pkg/controller/plugin/objectTemplate/plugin_test.go
+++ b/pkg/controller/plugin/objectTemplate/plugin_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/hashicorp/go-hclog"
+	"github.com/rigdev/rig/pkg/api/v1alpha2"
+	"github.com/rigdev/rig/pkg/controller/pipeline"
+	"github.com/rigdev/rig/pkg/ptr"
+	"github.com/rigdev/rig/pkg/scheme"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestObjectPlugin(t *testing.T) {
+	name, namespace := "name", "namespace"
+	tests := []struct {
+		name      string
+		capsule   *v1alpha2.Capsule
+		current   *appsv1.Deployment
+		patchYAML string
+		expected  *appsv1.Deployment
+	}{
+		{
+			name:    "empty patch",
+			capsule: &v1alpha2.Capsule{},
+			current: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.New[int32](1),
+				},
+			},
+			patchYAML: "{}",
+			expected: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.New[int32](1),
+				},
+			},
+		},
+		{
+			name:    "overwrite replicas",
+			capsule: &v1alpha2.Capsule{},
+			current: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.New[int32](1),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"label": "value",
+						},
+					},
+				},
+			},
+			patchYAML: `
+spec:
+  replicas: 2`,
+			expected: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"label": "value",
+						},
+					},
+					Replicas: ptr.New[int32](2),
+				},
+			},
+		},
+		{
+			name:    "add label",
+			capsule: &v1alpha2.Capsule{},
+			current: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.New[int32](1),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"label": "value",
+						},
+					},
+				},
+			},
+			patchYAML: `
+spec:
+  selector:
+    matchLabels:
+      label2: value2`,
+			expected: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"label":  "value",
+							"label2": "value2",
+						},
+					},
+					Replicas: ptr.New[int32](1),
+				},
+			},
+		},
+		{
+			name: "template using capsule",
+			capsule: &v1alpha2.Capsule{
+				Spec: v1alpha2.CapsuleSpec{
+					Image: "image",
+				},
+			},
+			current: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{},
+			},
+			patchYAML: `
+spec:
+  selector:
+    matchLabels:
+      label: {{ .capsule.spec.image }}`,
+			expected: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"label": "image",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Parallel()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.capsule.Namespace = namespace
+			tt.capsule.Name = name
+			p := pipeline.New(nil, nil, scheme.New(), logr.FromContextOrDiscard(context.Background()))
+			req := pipeline.NewCapsuleRequest(p, tt.capsule)
+			req.Set(tt.current)
+			plugin := objectTemplatePlugin{
+				config: Config{
+					Object: tt.patchYAML,
+					Group:  "apps",
+					Kind:   "Deployment",
+					Name:   name,
+				},
+			}
+			err := plugin.Run(context.Background(), req, hclog.Default())
+			assert.Nil(t, err)
+			deploy := &appsv1.Deployment{}
+			err = req.GetNew(deploy)
+			tt.expected.Name = name
+			tt.expected.Namespace = namespace
+			assert.Nil(t, err)
+			assert.Equal(t, tt.expected, deploy)
+		})
+	}
+}

--- a/pkg/controller/service_account_step.go
+++ b/pkg/controller/service_account_step.go
@@ -21,6 +21,10 @@ func (s *ServiceAccountStep) Apply(_ context.Context, req pipeline.CapsuleReques
 
 func (s *ServiceAccountStep) createServiceAccount(req pipeline.CapsuleRequest) *corev1.ServiceAccount {
 	sa := &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceAccount",
+			APIVersion: "v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      req.Capsule().Name,
 			Namespace: req.Capsule().Namespace,

--- a/pkg/controller/service_monitor_step.go
+++ b/pkg/controller/service_monitor_step.go
@@ -25,6 +25,10 @@ func (s *ServiceMonitorStep) Apply(_ context.Context, req pipeline.CapsuleReques
 
 func (s *ServiceMonitorStep) createPrometheusServiceMonitor(req pipeline.CapsuleRequest) *monitorv1.ServiceMonitor {
 	return &monitorv1.ServiceMonitor{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ServiceMonitor",
+			APIVersion: "monitoring.coreos.com/v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            req.Capsule().Name,
 			Namespace:       req.Capsule().Namespace,

--- a/pkg/controller/vpa_step.go
+++ b/pkg/controller/vpa_step.go
@@ -31,6 +31,9 @@ func (s *VPAStep) Apply(_ context.Context, req pipeline.CapsuleRequest) error {
 
 func (s *VPAStep) createVPA(req pipeline.CapsuleRequest) *vpav1.VerticalPodAutoscaler {
 	vpa := &vpav1.VerticalPodAutoscaler{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "VerticalPodAutoscaler",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      req.Capsule().Name,
 			Namespace: req.Capsule().Namespace,

--- a/pkg/obj/merge.go
+++ b/pkg/obj/merge.go
@@ -11,42 +11,53 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml/merge2"
 )
 
-type Merger interface {
-	Merge(src, dst runtime.Object) error
-}
-
-func NewMerger(scheme *runtime.Scheme) Merger {
+func NewSerializer(scheme *runtime.Scheme) runtime.Serializer {
 	codecs := serializer.NewCodecFactory(scheme)
-
 	info, _ := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), runtime.ContentTypeJSON)
-
-	return &merger{
-		serializer: info.Serializer,
-	}
+	return info.Serializer
 }
 
-type merger struct {
-	serializer runtime.Serializer
-}
+// Merge applies 'source' as a patch to 'dest', returning a new object containing the merge result.
+// It requires that 'dest' has APIVersion and Kind set.
+// This function is dangerous to use with objects derived from yaml/json when fields don't have omitEmpty
+// Consider a field with no omitEmpty JSON tag. If this field is not set in 'source', if will be present as an empty
+// value in the JSON of 'source' and then overwrite whatever the field had in 'dest'.
+func Merge[T runtime.Object](source runtime.Object, dest T, serializer runtime.Serializer) (T, error) {
+	var empty T
 
-func (m *merger) Merge(src, dst runtime.Object) error {
 	var srcB bytes.Buffer
-	if err := m.serializer.Encode(src, &srcB); err != nil {
-		return fmt.Errorf("could not encode source obj: %w", err)
+	if err := serializer.Encode(source, &srcB); err != nil {
+		return empty, fmt.Errorf("could not encode source obj: %w", err)
 	}
 
 	var dstB bytes.Buffer
-	if err := m.serializer.Encode(dst, &dstB); err != nil {
-		return fmt.Errorf("could not encode destination obj: %w", err)
+	if err := serializer.Encode(dest, &dstB); err != nil {
+		return empty, fmt.Errorf("could not encode destination obj: %w", err)
 	}
 
-	out, err := strategicpatch.StrategicMergePatch(dstB.Bytes(), srcB.Bytes(), dst)
+	out, err := strategicpatch.StrategicMergePatch(dstB.Bytes(), srcB.Bytes(), dest)
 	if err == nil {
-		if _, _, err := m.serializer.Decode(out, nil, dst); err != nil {
-			return err
+		// Previously, we discarded the output and used 'dst' as 'into'. This introduced a bug in the following scenario:
+		// Consider
+		// type obj Struct {
+		// 	list []struct{
+		// 		name string
+		// 		value string
+		// 	}
+		// }
+		// where we merge 'obj's by merging their 'list' fields on 'name'. Having two obj's of
+		// source := obj{list: [{name: "n1", value: "v1"}, {name: "n2", value: "v2"}]
+		// dest := obj{list: [{name: "n1", value: "vv"}, {name: "n3", value: ""}]
+		// We expect
+		// result == obj{list: [{name: "n1", value: "vv"}, {name: "n3", value: ""}, {name: "n2", value: "v2"}]
+		// but got (note 'value' of the second element)
+		// result == obj{list: [{name: "n1", value: "vv"}, {name: "n3", value: "v2"}, {name: "n2", value: "v2"}]
+		gvk := dest.GetObjectKind().GroupVersionKind()
+		res, _, err := serializer.Decode(out, &gvk, nil)
+		if err != nil {
+			return empty, err
 		}
-
-		return nil
+		return convert[T](res)
 	}
 
 	// Alternative solution:
@@ -65,28 +76,37 @@ func (m *merger) Merge(src, dst runtime.Object) error {
 
 	srcRN, err := yaml.Parse(srcB.String())
 	if err != nil {
-		return fmt.Errorf("could not parse source yaml: %w", err)
+		return empty, fmt.Errorf("could not parse source yaml: %w", err)
 	}
 
 	dstRN, err := yaml.Parse(dstB.String())
 	if err != nil {
-		return fmt.Errorf("could not parse destination yaml: %w", err)
+		return empty, fmt.Errorf("could not parse destination yaml: %w", err)
 	}
 
 	resRN, err := merge2.Merge(srcRN, dstRN, yaml.MergeOptions{})
 	if err != nil {
-		return fmt.Errorf("could not merge documents: %w", err)
+		return empty, fmt.Errorf("could not merge documents: %w", err)
 	}
 
 	res, err := resRN.String()
 	if err != nil {
-		return fmt.Errorf("could not reserialize merged document: %w", err)
+		return empty, fmt.Errorf("could not reserialize merged document: %w", err)
 	}
 
-	_, _, err = m.serializer.Decode([]byte(res), nil, dst)
+	output, _, err := serializer.Decode([]byte(res), nil, nil)
 	if err != nil {
-		return fmt.Errorf("could not decode merged document: %w", err)
+		return empty, fmt.Errorf("could not decode merged document: %w", err)
 	}
 
-	return nil
+	return convert[T](output)
+}
+
+func convert[T any](obj any) (T, error) {
+	objT, ok := obj.(T)
+	if !ok {
+		var empty T
+		return empty, fmt.Errorf("expected output to have type %T, it had type %T", empty, obj)
+	}
+	return objT, nil
 }

--- a/pkg/obj/merge_test.go
+++ b/pkg/obj/merge_test.go
@@ -1,186 +1,342 @@
-package obj_test
+package obj
 
 import (
 	"testing"
 
 	"github.com/rigdev/rig/pkg/api/config/v1alpha1"
-	"github.com/rigdev/rig/pkg/obj"
+	"github.com/rigdev/rig/pkg/ptr"
 	"github.com/rigdev/rig/pkg/scheme"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
 
 func TestMerger(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
-		name     string
-		src      runtime.Object
-		dst      runtime.Object
-		expected runtime.Object
-	}{
-		{
-			name: "test override",
-			src: &v1alpha1.PlatformConfig{
-				TypeMeta: v1.TypeMeta{
-					Kind:       "PlatformConfig",
-					APIVersion: v1alpha1.GroupVersion.String(),
-				},
-				Auth: v1alpha1.Auth{
-					SSO: v1alpha1.SSO{
-						OIDCProviders: map[string]v1alpha1.OIDCProvider{
-							"test": {
-								ClientSecret: "secret",
-							},
-						},
-					},
-				},
+
+	testMerge(t, "test override",
+		&v1alpha1.PlatformConfig{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "PlatformConfig",
+				APIVersion: v1alpha1.GroupVersion.String(),
 			},
-			dst: &v1alpha1.PlatformConfig{
-				TypeMeta: v1.TypeMeta{
-					Kind:       "PlatformConfig",
-					APIVersion: v1alpha1.GroupVersion.String(),
-				},
-				Auth: v1alpha1.Auth{
-					SSO: v1alpha1.SSO{
-						OIDCProviders: map[string]v1alpha1.OIDCProvider{
-							"test": {
-								ClientID: "id",
-							},
-						},
-					},
-				},
-			},
-			expected: &v1alpha1.PlatformConfig{
-				TypeMeta: v1.TypeMeta{
-					Kind:       "PlatformConfig",
-					APIVersion: v1alpha1.GroupVersion.String(),
-				},
-				Auth: v1alpha1.Auth{
-					SSO: v1alpha1.SSO{
-						OIDCProviders: map[string]v1alpha1.OIDCProvider{
-							"test": {
-								ClientID:     "id",
-								ClientSecret: "secret",
-							},
+			Auth: v1alpha1.Auth{
+				SSO: v1alpha1.SSO{
+					OIDCProviders: map[string]v1alpha1.OIDCProvider{
+						"test": {
+							ClientSecret: "secret",
 						},
 					},
 				},
 			},
 		},
-		{
-			name: "test container change",
-			src: &corev1.Pod{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:    "c2",
-							Image:   "image2",
-							Command: []string{"cmd2-new"},
-							Args:    []string{"arg1, arg2"},
-						},
-					},
-				},
+		&v1alpha1.PlatformConfig{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "PlatformConfig",
+				APIVersion: v1alpha1.GroupVersion.String(),
 			},
-			dst: &corev1.Pod{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:    "c1",
-							Image:   "image1",
-							Command: []string{"cmd1"},
-						},
-						{
-							Name:    "c2",
-							Image:   "image2",
-							Command: []string{"cmd2"},
-						},
-					},
-				},
-			},
-			expected: &corev1.Pod{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:    "c1",
-							Image:   "image1",
-							Command: []string{"cmd1"},
-						},
-						{
-							Name:    "c2",
-							Image:   "image2",
-							Command: []string{"cmd2-new"},
-							Args:    []string{"arg1, arg2"},
+			Auth: v1alpha1.Auth{
+				SSO: v1alpha1.SSO{
+					OIDCProviders: map[string]v1alpha1.OIDCProvider{
+						"test": {
+							ClientID: "id",
 						},
 					},
 				},
 			},
 		},
-		{
-			name: "test container add",
-			src: &corev1.Pod{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:    "c3",
-							Image:   "image3",
-							Command: []string{"cmd3"},
-						},
-					},
-				},
+		&v1alpha1.PlatformConfig{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "PlatformConfig",
+				APIVersion: v1alpha1.GroupVersion.String(),
 			},
-			dst: &corev1.Pod{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:    "c1",
-							Image:   "image1",
-							Command: []string{"cmd1"},
-						},
-						{
-							Name:    "c2",
-							Image:   "image2",
-							Command: []string{"cmd2"},
-						},
-					},
-				},
-			},
-			expected: &corev1.Pod{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:    "c3",
-							Image:   "image3",
-							Command: []string{"cmd3"},
-						},
-						{
-							Name:    "c1",
-							Image:   "image1",
-							Command: []string{"cmd1"},
-						},
-						{
-							Name:    "c2",
-							Image:   "image2",
-							Command: []string{"cmd2"},
+			Auth: v1alpha1.Auth{
+				SSO: v1alpha1.SSO{
+					OIDCProviders: map[string]v1alpha1.OIDCProvider{
+						"test": {
+							ClientID:     "id",
+							ClientSecret: "secret",
 						},
 					},
 				},
 			},
 		},
+	)
+
+	podMeta := metav1.TypeMeta{
+		Kind:       "Pod",
+		APIVersion: "v1",
 	}
+	testMerge(t, "test container change",
+		&corev1.Pod{
+			TypeMeta: podMeta,
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    "c2",
+						Image:   "image2",
+						Command: []string{"cmd2-new"},
+						Args:    []string{"arg1, arg2"},
+					},
+				},
+			},
+		},
+		&corev1.Pod{
+			TypeMeta: podMeta,
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    "c1",
+						Image:   "image1",
+						Command: []string{"cmd1"},
+					},
+					{
+						Name:    "c2",
+						Image:   "image2",
+						Command: []string{"cmd2"},
+					},
+				},
+			},
+		},
+		&corev1.Pod{
+			TypeMeta: podMeta,
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    "c1",
+						Image:   "image1",
+						Command: []string{"cmd1"},
+					},
+					{
+						Name:    "c2",
+						Image:   "image2",
+						Command: []string{"cmd2-new"},
+						Args:    []string{"arg1, arg2"},
+					},
+				},
+			},
+		},
+	)
+	testMerge(t, "test container add",
+		&corev1.Pod{
+			TypeMeta: podMeta,
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    "c3",
+						Image:   "image3",
+						Command: []string{"cmd3"},
+					},
+				},
+			},
+		},
+		&corev1.Pod{
+			TypeMeta: podMeta,
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    "c1",
+						Image:   "image1",
+						Command: []string{"cmd1"},
+					},
+					{
+						Name:    "c2",
+						Image:   "image2",
+						Command: []string{"cmd2"},
+					},
+				},
+			},
+		},
+		&corev1.Pod{
+			TypeMeta: podMeta,
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    "c3",
+						Image:   "image3",
+						Command: []string{"cmd3"},
+					},
+					{
+						Name:    "c1",
+						Image:   "image1",
+						Command: []string{"cmd1"},
+					},
+					{
+						Name:    "c2",
+						Image:   "image2",
+						Command: []string{"cmd2"},
+					},
+				},
+			},
+		},
+	)
+	testMerge(t, "test container merge",
+		&corev1.Pod{
+			TypeMeta: podMeta,
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "c1",
+						Image: "image3",
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "port1",
+								ContainerPort: 1001,
+								HostPort:      6969,
+								HostIP:        "some-ip",
+							},
+							{
+								Name:          "port3",
+								HostPort:      5555,
+								ContainerPort: 1003,
+							},
+							{
+								Name:          "port4",
+								HostPort:      4567,
+								ContainerPort: 1004,
+							},
+						},
+					},
+				},
+			},
+		},
+		&corev1.Pod{
+			TypeMeta: podMeta,
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    "c1",
+						Image:   "image1",
+						Command: []string{"cmd1"},
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "port1",
+								ContainerPort: 1001,
+								HostPort:      8080,
+								Protocol:      "protocol",
+							},
+							{
+								Name:          "port2",
+								ContainerPort: 1002,
+								HostPort:      1234,
+								HostIP:        "ip",
+							},
+						},
+					},
+					{
+						Name:    "c2",
+						Image:   "image2",
+						Command: []string{"cmd2"},
+					},
+				},
+			},
+		},
+		&corev1.Pod{
+			TypeMeta: podMeta,
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    "c1",
+						Image:   "image3",
+						Command: []string{"cmd1"},
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "port1",
+								HostPort:      6969,
+								HostIP:        "some-ip",
+								Protocol:      "protocol",
+								ContainerPort: 1001,
+							},
+							{
+								Name:          "port3",
+								HostPort:      5555,
+								ContainerPort: 1003,
+							},
+							{
+								Name:          "port4",
+								HostPort:      4567,
+								ContainerPort: 1004,
+							},
+							{
+								Name:          "port2",
+								HostPort:      1234,
+								HostIP:        "ip",
+								ContainerPort: 1002,
+							},
+						},
+					},
+					{
+						Name:    "c2",
+						Image:   "image2",
+						Command: []string{"cmd2"},
+					},
+				},
+			},
+		},
+	)
 
-	merger := obj.NewMerger(scheme.New())
-
-	for i := range tests {
-		test := tests[i]
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-
-			err := merger.Merge(test.src, test.dst)
-			assert.NoError(t, err)
-
-			assert.Equal(t, test.expected, test.dst)
-		})
+	deploymentMeta := metav1.TypeMeta{
+		Kind:       "Deployment",
+		APIVersion: "apps/v1",
 	}
+	testMerge(t, "JSON omitEmpty behaviour",
+		&appsv1.Deployment{
+			TypeMeta: deploymentMeta,
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr.New[int32](2),
+			},
+		},
+		&appsv1.Deployment{
+			TypeMeta: deploymentMeta,
+			Spec: appsv1.DeploymentSpec{
+				Replicas:        ptr.New[int32](1),
+				MinReadySeconds: 1, // Not overwritten (has omitempty)
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{ // Overwritten (no omitEmpty)
+							Image: "some-image",
+						}},
+						InitContainers: []corev1.Container{{ // Not overwritten (has omitEmpty)
+							Image: "init-image",
+						}},
+					},
+				},
+				Selector: &v1.LabelSelector{ // Overwritten (no omitEmpty)
+					MatchLabels: map[string]string{ // Has omitEmpty, but because parent field doesn't have, it gets overwritten
+						"some-label": "some-value",
+					},
+				},
+			},
+		},
+		&appsv1.Deployment{
+			TypeMeta: deploymentMeta,
+			Spec: appsv1.DeploymentSpec{
+				Replicas:        ptr.New[int32](2),
+				MinReadySeconds: 1,
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						InitContainers: []corev1.Container{{
+							Image: "init-image",
+						}},
+					},
+				},
+			},
+		},
+	)
+}
+
+func testMerge[T runtime.Object](t *testing.T, name string, src, dst, expected T) {
+	codecs := serializer.NewCodecFactory(scheme.New())
+
+	info, _ := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), runtime.ContentTypeJSON)
+	t.Run(name, func(t *testing.T) {
+		t.Parallel()
+		res, err := Merge(src, dst, info.Serializer)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, res)
+	})
 }

--- a/pkg/obj/merge_test.go
+++ b/pkg/obj/merge_test.go
@@ -65,6 +65,7 @@ func TestMerger(t *testing.T) {
 				},
 			},
 		},
+		&v1alpha1.PlatformConfig{},
 	)
 
 	podMeta := metav1.TypeMeta{
@@ -120,6 +121,7 @@ func TestMerger(t *testing.T) {
 				},
 			},
 		},
+		&corev1.Pod{},
 	)
 	testMerge(t, "test container add",
 		&corev1.Pod{
@@ -173,6 +175,7 @@ func TestMerger(t *testing.T) {
 				},
 			},
 		},
+		&corev1.Pod{},
 	)
 	testMerge(t, "test container merge",
 		&corev1.Pod{
@@ -277,6 +280,7 @@ func TestMerger(t *testing.T) {
 				},
 			},
 		},
+		&corev1.Pod{},
 	)
 
 	deploymentMeta := metav1.TypeMeta{
@@ -326,16 +330,17 @@ func TestMerger(t *testing.T) {
 				},
 			},
 		},
+		&appsv1.Deployment{},
 	)
 }
 
-func testMerge[T runtime.Object](t *testing.T, name string, src, dst, expected T) {
+func testMerge[T runtime.Object](t *testing.T, name string, src, dst, expected, empty T) {
 	codecs := serializer.NewCodecFactory(scheme.New())
 
 	info, _ := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), runtime.ContentTypeJSON)
 	t.Run(name, func(t *testing.T) {
 		t.Parallel()
-		res, err := Merge(src, dst, info.Serializer)
+		res, err := Merge(src, dst, empty, info.Serializer)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, res)
 	})

--- a/pkg/service/config/config.go
+++ b/pkg/service/config/config.go
@@ -25,12 +25,10 @@ type Service interface {
 
 func NewService(scheme *runtime.Scheme, filePaths ...string) (Service, error) {
 	decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
-	merger := obj.NewMerger(scheme)
-
 	return newServiceBuilder().
 		withDecoder(decoder).
 		withFiles(filePaths...).
-		withMerger(merger).
+		withSerializer(obj.NewSerializer(scheme)).
 		build()
 }
 
@@ -55,11 +53,11 @@ func (s *service) Platform() *v1alpha1.PlatformConfig {
 }
 
 type serviceBuilder struct {
-	oCFG      *v1alpha1.OperatorConfig
-	pCFG      *v1alpha1.PlatformConfig
-	decoder   runtime.Decoder
-	merger    obj.Merger
-	filePaths []string
+	oCFG       *v1alpha1.OperatorConfig
+	pCFG       *v1alpha1.PlatformConfig
+	decoder    runtime.Decoder
+	serializer runtime.Serializer
+	filePaths  []string
 }
 
 func newServiceBuilder() *serviceBuilder {
@@ -79,8 +77,8 @@ func (b *serviceBuilder) withFiles(filePaths ...string) *serviceBuilder {
 	return b
 }
 
-func (b *serviceBuilder) withMerger(merger obj.Merger) *serviceBuilder {
-	b.merger = merger
+func (b *serviceBuilder) withSerializer(serializer runtime.Serializer) *serviceBuilder {
+	b.serializer = serializer
 	return b
 }
 
@@ -99,7 +97,9 @@ func (b *serviceBuilder) build() (*service, error) {
 	if err := getCFGFromEnv(&oCFGFromEnv); err != nil {
 		return nil, err
 	}
-	if err := b.merger.Merge(&oCFGFromEnv, b.oCFG); err != nil {
+	var err error
+	b.oCFG, err = obj.Merge(&oCFGFromEnv, b.oCFG, b.serializer)
+	if err != nil {
 		return nil, fmt.Errorf("could not merge env config: %w", err)
 	}
 
@@ -107,7 +107,9 @@ func (b *serviceBuilder) build() (*service, error) {
 	if err := getCFGFromEnv(&pCFGFromEnv); err != nil {
 		return nil, err
 	}
-	if err := b.merger.Merge(&pCFGFromEnv, b.pCFG); err != nil {
+
+	b.pCFG, err = obj.Merge(&pCFGFromEnv, b.pCFG, b.serializer)
+	if err != nil {
 		return nil, fmt.Errorf("could not merge env config: %w", err)
 	}
 	b.oCFG.Default()
@@ -116,7 +118,9 @@ func (b *serviceBuilder) build() (*service, error) {
 }
 
 func (b *serviceBuilder) decode(data []byte) error {
-	obj, gvk, err := b.decoder.Decode(data, nil, nil)
+	var err error
+
+	object, gvk, err := b.decoder.Decode(data, nil, nil)
 	if err != nil {
 		return &ErrDecoding{err: err}
 	}
@@ -130,7 +134,7 @@ func (b *serviceBuilder) decode(data []byte) error {
 		var decodedCFG *v1alpha1.OperatorConfig
 		switch gvk.Version {
 		case v1alpha1.GroupVersion.Version:
-			cfg, ok := obj.(*v1alpha1.OperatorConfig)
+			cfg, ok := object.(*v1alpha1.OperatorConfig)
 			if !ok {
 				return &ErrRuntimeObjectAssertion{
 					gvk:    gvk,
@@ -141,14 +145,15 @@ func (b *serviceBuilder) decode(data []byte) error {
 		default:
 			return fmt.Errorf("unsupport api version: %s", gvk.Version)
 		}
-		if err := b.merger.Merge(decodedCFG, b.oCFG); err != nil {
+		b.oCFG, err = obj.Merge(decodedCFG, b.oCFG, b.serializer)
+		if err != nil {
 			return fmt.Errorf("could not merge operator config: %w", err)
 		}
 	case "PlatformConfig":
 		var decodedCFG *v1alpha1.PlatformConfig
 		switch gvk.Version {
 		case v1alpha1.GroupVersion.Version:
-			cfg, ok := obj.(*v1alpha1.PlatformConfig)
+			cfg, ok := object.(*v1alpha1.PlatformConfig)
 			if !ok {
 				return &ErrRuntimeObjectAssertion{
 					gvk:    gvk,
@@ -159,7 +164,8 @@ func (b *serviceBuilder) decode(data []byte) error {
 		default:
 			return fmt.Errorf("unsupported api version: %s", gvk.Version)
 		}
-		if err := b.merger.Merge(decodedCFG, b.pCFG); err != nil {
+		b.pCFG, err = obj.Merge(decodedCFG, b.pCFG, b.serializer)
+		if err != nil {
 			return fmt.Errorf("could not merge platform config: %w", err)
 		}
 	default:

--- a/pkg/service/config/config.go
+++ b/pkg/service/config/config.go
@@ -98,7 +98,7 @@ func (b *serviceBuilder) build() (*service, error) {
 		return nil, err
 	}
 	var err error
-	b.oCFG, err = obj.Merge(&oCFGFromEnv, b.oCFG, b.serializer)
+	b.oCFG, err = obj.Merge(&oCFGFromEnv, b.oCFG, b.oCFG, b.serializer)
 	if err != nil {
 		return nil, fmt.Errorf("could not merge env config: %w", err)
 	}
@@ -108,7 +108,7 @@ func (b *serviceBuilder) build() (*service, error) {
 		return nil, err
 	}
 
-	b.pCFG, err = obj.Merge(&pCFGFromEnv, b.pCFG, b.serializer)
+	b.pCFG, err = obj.Merge(&pCFGFromEnv, b.pCFG, b.pCFG, b.serializer)
 	if err != nil {
 		return nil, fmt.Errorf("could not merge env config: %w", err)
 	}
@@ -145,7 +145,7 @@ func (b *serviceBuilder) decode(data []byte) error {
 		default:
 			return fmt.Errorf("unsupport api version: %s", gvk.Version)
 		}
-		b.oCFG, err = obj.Merge(decodedCFG, b.oCFG, b.serializer)
+		b.oCFG, err = obj.Merge(decodedCFG, b.oCFG, b.oCFG, b.serializer)
 		if err != nil {
 			return fmt.Errorf("could not merge operator config: %w", err)
 		}
@@ -164,7 +164,7 @@ func (b *serviceBuilder) decode(data []byte) error {
 		default:
 			return fmt.Errorf("unsupported api version: %s", gvk.Version)
 		}
-		b.pCFG, err = obj.Merge(decodedCFG, b.pCFG, b.serializer)
+		b.pCFG, err = obj.Merge(decodedCFG, b.pCFG, b.pCFG, b.serializer)
 		if err != nil {
 			return fmt.Errorf("could not merge platform config: %w", err)
 		}

--- a/pkg/service/config/config_test.go
+++ b/pkg/service/config/config_test.go
@@ -123,7 +123,7 @@ ingress:
 	}
 
 	sch := scheme.New()
-	merger := obj.NewMerger(sch)
+	ser := obj.NewSerializer(sch)
 	decoder := serializer.NewCodecFactory(sch).UniversalDeserializer()
 
 	for i := range tests {
@@ -151,7 +151,7 @@ ingress:
 			s, err := newServiceBuilder().
 				withDecoder(decoder).
 				withFiles(fileNames...).
-				withMerger(merger).
+				withSerializer(ser).
 				build()
 			if test.err != nil {
 				require.ErrorAs(t, err, &test.err)

--- a/test/integration/k8s/capsule_controller_test.go
+++ b/test/integration/k8s/capsule_controller_test.go
@@ -32,7 +32,6 @@ import (
 var nsName types.NamespacedName
 
 func (s *K8sTestSuite) TestControllerSharedSecrets() {
-	return
 	ctx := context.Background()
 	nsName = types.NamespacedName{
 		Name:      uuid.NewString(),
@@ -255,7 +254,6 @@ func (s *K8sTestSuite) TestControllerSharedSecrets() {
 }
 
 func (s *K8sTestSuite) TestController() {
-	return
 	nsName = types.NamespacedName{
 		Name:      "test",
 		Namespace: "nginx",

--- a/test/integration/k8s/capsule_controller_test.go
+++ b/test/integration/k8s/capsule_controller_test.go
@@ -32,6 +32,7 @@ import (
 var nsName types.NamespacedName
 
 func (s *K8sTestSuite) TestControllerSharedSecrets() {
+	return
 	ctx := context.Background()
 	nsName = types.NamespacedName{
 		Name:      uuid.NewString(),
@@ -254,6 +255,7 @@ func (s *K8sTestSuite) TestControllerSharedSecrets() {
 }
 
 func (s *K8sTestSuite) TestController() {
+	return
 	nsName = types.NamespacedName{
 		Name:      "test",
 		Namespace: "nginx",


### PR DESCRIPTION
We now properly handle merging of child lists which contain a 'mergeKey'
Essentially, we just make sure to adhere to JSON Merge Path (https://datatracker.ietf.org/doc/html/rfc7386)
