### PR TITLE
:recycle: Refactored how we handle templating in plugins

### DIFF
--- a/pkg/controller/plugin/helpers.go
+++ b/pkg/controller/plugin/helpers.go
@@ -33,6 +33,8 @@ func GetNew(group, kind, name string, req pipeline.CapsuleRequest) (client.Objec
 
 type ParseStep[T any] func(config T, req pipeline.CapsuleRequest) (string, any, error)
 
+// Using this, we parse the config at every execution of the plugin.
+// If we get performance issues due to that we can try and optimize that.
 func ParseTemplatedConfig[T any](data []byte, req pipeline.CapsuleRequest, steps ...ParseStep[T]) (T, error) {
 	var config, empty T
 


### PR DESCRIPTION
Part of the refactor is to also handle cases where we need to
do templating in a series of steps. E.g. objectTemplate can use
capsule and currentObject as template values, if the name of currentObject
is templated on the capsule, then you first need to template the config
using the capsule, then fetch the currentObject, then template again.
