### PR TITLE
✨ Add apicheck post-install helm hook

### DIFF
--- a/cmd/rig-operator/apichecker/apichecker.go
+++ b/cmd/rig-operator/apichecker/apichecker.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	flagInterval = "interval"
-	flagTimeout  = "timeout"
+	flagInterval  = "interval"
+	flagTimeout   = "timeout"
+	flagNamespace = "namespace"
 )
 
 func CMD() *cobra.Command {
@@ -32,6 +33,10 @@ func CMD() *cobra.Command {
 				return err
 			}
 			timeout, err := cmd.Flags().GetDuration(flagTimeout)
+			if err != nil {
+				return err
+			}
+			namespace, err := cmd.Flags().GetString(flagNamespace)
 			if err != nil {
 				return err
 			}
@@ -51,7 +56,7 @@ func CMD() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("could not create k8s client for apicheck")
 			}
-			c = client.NewNamespacedClient(client.NewDryRunClient(c), "default")
+			c = client.NewNamespacedClient(client.NewDryRunClient(c), namespace)
 
 			log := log.New(false)
 
@@ -82,6 +87,7 @@ func CMD() *cobra.Command {
 	flags := cmd.Flags()
 	flags.Duration(flagInterval, time.Second*5, "interval for running check")
 	flags.Duration(flagTimeout, time.Minute*2, "timeout for when we should stop checking")
+	flags.String(flagNamespace, "rig-system", "namespace where Capsule resource creation will dryrun")
 
 	return cmd
 }

--- a/deploy/charts/rig-operator/templates/_helpers.tpl
+++ b/deploy/charts/rig-operator/templates/_helpers.tpl
@@ -67,3 +67,21 @@ Create the name of the config secret to use
 {{- define "rig-operator.secretName" -}}
 {{- default (include "rig-operator.fullname" .) .Values.secretName }}
 {{- end }}
+
+{{/*
+Create the fullname of apicheck resources
+*/}}
+{{- define "rig-operator.apicheck.fullname" -}}
+{{- include "rig-operator.fullname" . | printf "%s-apicheck" -}}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "rig-operator.apicheck.serviceAccountName" -}}
+{{- if .Values.apicheck.serviceAccount.create }}
+{{- default (include "rig-operator.apicheck.fullname" .) .Values.apicheck.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.apicheck.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/rig-operator/templates/apicheck/job.yaml
+++ b/deploy/charts/rig-operator/templates/apicheck/job.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.config.webhooksEnabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "rig-operator.apicheck.fullname" . }}
+  labels: {{ include "rig-operator.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.apicheck.backoffLimit }}
+  template:
+    spec:
+      serviceAccountName: {{ include "rig-operator.apicheck.serviceAccountName" . }}
+      securityContext: {{ .Values.apicheck.podSecurityContext | toYaml | nindent 8 }}
+      restartPolicy: OnFailure
+      containers:
+        - name: apicheck
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          securityContext: {{ .Values.apicheck.securityContext | toYaml | nindent 12 }}
+          command:
+            - "rig-operator"
+            - "apicheck"
+            - "--interval"
+            - {{ .Values.apicheck.interval | quote }}
+            - "--timeout"
+            - {{ .Values.apicheck.timeout | quote }}
+            - "--namespace"
+            - {{ .Release.Namespace | quote }}
+{{- end -}}

--- a/deploy/charts/rig-operator/templates/apicheck/rbac.yaml
+++ b/deploy/charts/rig-operator/templates/apicheck/rbac.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.config.webhooksEnabled .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "rig-operator.apicheck.fullname" . }}
+  labels: {{ include "rig-operator.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["rig.dev"]
+    resources: ["capsules"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "rig-operator.apicheck.fullname" . }}
+  labels: {{ include "rig-operator.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "rig-operator.apicheck.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "rig-operator.apicheck.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/deploy/charts/rig-operator/templates/apicheck/serviceaccount.yaml
+++ b/deploy/charts/rig-operator/templates/apicheck/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.config.webhooksEnabled .Values.apicheck.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "rig-operator.apicheck.serviceAccountName" . }}
+  labels: {{ include "rig-operator.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+{{- end }}

--- a/deploy/charts/rig-operator/values.yaml
+++ b/deploy/charts/rig-operator/values.yaml
@@ -138,3 +138,20 @@ serviceMonitor:
   enabled: false
   # labels set on the `ServiceMonitor`
   labels: {}
+
+apicheck:
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 15000
+    runAsGroup: 15000
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - "ALL"
+  backoffLimit: 4
+  serviceAccount:
+    create: true
+    name: ""
+  timeout: 2m
+  interval: 5s


### PR DESCRIPTION
This adds a post-install helm hook which will block the helm install
until the webhooks are reachable from the api server.