### PR TITLE
✨ Make optional cert-manager in helmchart

### DIFF
--- a/cmd/rig-operator/certgen/create.go
+++ b/cmd/rig-operator/certgen/create.go
@@ -118,11 +118,12 @@ func generateCerts(hosts []string) (*certs, error) {
 	}
 
 	notBefore := time.Now().Add(time.Minute * -5)
+	notAfter := notBefore.Add(time.Hour * 24 * 365 * 100)
 
 	rootTemplate := x509.Certificate{
 		SerialNumber:          sn,
 		NotBefore:             notBefore,
-		NotAfter:              notBefore.Add(time.Hour * 24 * 365 * 100),
+		NotAfter:              notAfter,
 		KeyUsage:              x509.KeyUsageCertSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
@@ -157,6 +158,8 @@ func generateCerts(hosts []string) (*certs, error) {
 
 	template := x509.Certificate{
 		SerialNumber: sn,
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
 		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		Subject: pkix.Name{

--- a/cmd/rig-operator/certgen/k8s.go
+++ b/cmd/rig-operator/certgen/k8s.go
@@ -63,10 +63,11 @@ func (k *k8s) createSecret(ctx context.Context, namespace, name string, certs *c
 			Namespace: namespace,
 			Name:      name,
 		},
+		Type: v1.SecretTypeTLS,
 		Data: map[string][]byte{
-			"ca":   certs.ca,
-			"cert": certs.cert,
-			"key":  certs.key,
+			"ca.crt":  certs.ca,
+			"tls.crt": certs.cert,
+			"tls.key": certs.key,
 		},
 	}
 

--- a/cmd/rig-operator/certgen/patch.go
+++ b/cmd/rig-operator/certgen/patch.go
@@ -19,9 +19,9 @@ const (
 
 func patchCMD() (*cobra.Command, error) {
 	cmd := &cobra.Command{
-		Use:   "patch-webhook-config",
+		Use:   "patch",
 		Args:  cobra.ExactArgs(0),
-		Short: "Patch a validating/mutating webhook configuration",
+		Short: "Patch validating/mutating webhook configurations and CRDs",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flags := cmd.Flags()
 			webhookCFGName, err := flags.GetString(flagWebhookCFGName)
@@ -69,7 +69,7 @@ func patchCMD() (*cobra.Command, error) {
 				return fmt.Errorf("could not get secret: %w", err)
 			}
 
-			ca := s.Data["ca"]
+			ca := s.Data["ca.crt"]
 			if ca == nil {
 				return fmt.Errorf("secret %s/%s does not contain ca", secretNamespace, secretName)
 			}

--- a/deploy/charts/rig-operator/templates/_helpers.tpl
+++ b/deploy/charts/rig-operator/templates/_helpers.tpl
@@ -85,3 +85,21 @@ Create the name of the service account to use
 {{- default "default" .Values.apicheck.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the fullname of certgen create
+*/}}
+{{- define "rig-operator.certgen.fullname" -}}
+{{- include "rig-operator.fullname" . | printf "%s-certgen" -}}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "rig-operator.certgen.serviceAccountName" -}}
+{{- if .Values.certgen.serviceAccount.create }}
+{{- default (include "rig-operator.certgen.fullname" .) .Values.certgen.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.certgen.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/rig-operator/templates/apicheck/rbac.yaml
+++ b/deploy/charts/rig-operator/templates/apicheck/rbac.yaml
@@ -5,8 +5,7 @@ metadata:
   name: {{ include "rig-operator.apicheck.fullname" . }}
   labels: {{ include "rig-operator.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: post-install
-    helm.sh/hook-weight: "-5"
+    helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups: ["rig.dev"]
@@ -19,8 +18,7 @@ metadata:
   name: {{ include "rig-operator.apicheck.fullname" . }}
   labels: {{ include "rig-operator.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: post-install
-    helm.sh/hook-weight: "-5"
+    helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -28,6 +26,6 @@ roleRef:
   name: {{ include "rig-operator.apicheck.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "rig-operator.apicheck.fullname" . }}
+    name: {{ include "rig-operator.apicheck.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/deploy/charts/rig-operator/templates/apicheck/serviceaccount.yaml
+++ b/deploy/charts/rig-operator/templates/apicheck/serviceaccount.yaml
@@ -1,11 +1,10 @@
-{{- if and .Values.config.webhooksEnabled .Values.apicheck.serviceAccount.create }}
+{{- if and .Values.config.webhooksEnabled .Values.apicheck.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "rig-operator.apicheck.serviceAccountName" . }}
   labels: {{ include "rig-operator.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: post-install
-    helm.sh/hook-weight: "-5"
+    helm.sh/hook: post-install,post-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
-{{- end }}
+{{- end -}}

--- a/deploy/charts/rig-operator/templates/certgen/create-job.yaml
+++ b/deploy/charts/rig-operator/templates/certgen/create-job.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.config.webhooksEnabled (not .Values.certManager.enabled) -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "rig-operator.certgen.fullname" . }}
+  labels: {{ include "rig-operator.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.certgen.backoffLimit }}
+  template:
+    spec:
+      serviceAccountName: {{ include "rig-operator.certgen.serviceAccountName" . }}
+      securityContext: {{ .Values.certgen.podSecurityContext | toYaml | nindent 8 }}
+      restartPolicy: OnFailure
+      containers:
+        - name: certgen
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          securityContext: {{ .Values.certgen.securityContext | toYaml | nindent 12 }}
+          command:
+            - "rig-operator"
+            - "certgen"
+            - "create"
+            - "{{ include "rig-operator.fullname" . }}-webhook-tls"
+            - "--hosts={{ include "rig-operator.fullname" . }},{{ include "rig-operator.fullname" . }}.{{ .Release.Namespace }}.svc"
+            - "--namespace={{ .Release.Namespace }}"
+{{- end -}}

--- a/deploy/charts/rig-operator/templates/certgen/patch-job.yaml
+++ b/deploy/charts/rig-operator/templates/certgen/patch-job.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.config.webhooksEnabled (not .Values.certManager.enabled) -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "rig-operator.certgen.fullname" . }}
+  labels: {{ include "rig-operator.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.certgen.backoffLimit }}
+  template:
+    spec:
+      serviceAccountName: {{ include "rig-operator.certgen.serviceAccountName" . }}
+      securityContext: {{ .Values.certgen.podSecurityContext | toYaml | nindent 8 }}
+      restartPolicy: OnFailure
+      containers:
+        - name: certgen
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          securityContext: {{ .Values.certgen.securityContext | toYaml | nindent 12 }}
+          command:
+            - "rig-operator"
+            - "certgen"
+            - "patch"
+            - "--secret-name={{ include "rig-operator.fullname" . }}-webhook-tls"
+            - "--secret-namespace={{ .Release.Namespace }}"
+            - "--webhook-cfg-name={{ include "rig-operator.fullname" . }}"
+{{- end -}}

--- a/deploy/charts/rig-operator/templates/certgen/rbac.yaml
+++ b/deploy/charts/rig-operator/templates/certgen/rbac.yaml
@@ -1,0 +1,64 @@
+{{- if and .Values.config.webhooksEnabled .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "rig-operator.certgen.fullname" . }}
+  labels: {{ include "rig-operator.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "rig-operator.certgen.fullname" . }}
+  labels: {{ include "rig-operator.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "rig-operator.certgen.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "rig-operator.certgen.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "rig-operator.certgen.fullname" . }}
+  labels: {{ include "rig-operator.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+    verbs: ["get", "update"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "rig-operator.certgen.fullname" . }}
+  labels: {{ include "rig-operator.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "rig-operator.certgen.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "rig-operator.certgen.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/deploy/charts/rig-operator/templates/certgen/serviceaccount.yaml
+++ b/deploy/charts/rig-operator/templates/certgen/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.config.webhooksEnabled .Values.certgen.serviceAccount.create (not .Values.certManager.enabled) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "rig-operator.certgen.serviceAccountName" . }}
+  labels: {{ include "rig-operator.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+{{- end -}}

--- a/deploy/charts/rig-operator/templates/certificate.yaml
+++ b/deploy/charts/rig-operator/templates/certificate.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config.webhooksEnabled }}
+{{- if and .Values.config.webhooksEnabled .Values.certManager.enabled -}}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -20,4 +20,4 @@ spec:
     kind: Issuer
     name: {{ include "rig-operator.fullname" . }}-webhook
   secretName: {{ include "rig-operator.fullname" . }}-webhook-tls
-{{- end }}
+{{- end -}}

--- a/deploy/charts/rig-operator/templates/crd.yaml
+++ b/deploy/charts/rig-operator/templates/crd.yaml
@@ -5,7 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
-    {{- if .Values.config.webhooksEnabled }}
+    {{- if and .Values.config.webhooksEnabled .Values.certManager.enabled }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "rig-operator.fullname" . }}-webhook
     {{- end }}
   name: capsules.rig.dev

--- a/deploy/charts/rig-operator/templates/webhookconfiguration.yaml
+++ b/deploy/charts/rig-operator/templates/webhookconfiguration.yaml
@@ -4,8 +4,10 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: {{ include "rig-operator.fullname" . }}
   labels: {{ include "rig-operator.labels" . | nindent 4 }}
+  {{- if .Values.certManager.enabled }}
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "rig-operator.fullname" . }}-webhook
+  {{- end }}
 webhooks:
 - admissionReviewVersions:
   - v1
@@ -34,8 +36,10 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ include "rig-operator.fullname" . }}
   labels: {{ include "rig-operator.labels" . | nindent 4 }}
+  {{- if .Values.certManager.enabled }}
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "rig-operator.fullname" . }}-webhook
+  {{- end }}
 webhooks:
 - admissionReviewVersions:
   - v1

--- a/deploy/charts/rig-operator/values.yaml
+++ b/deploy/charts/rig-operator/values.yaml
@@ -160,3 +160,23 @@ apicheck:
     name: ""
   timeout: 2m
   interval: 5s
+
+certgen:
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 15000
+    runAsGroup: 15000
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - "ALL"
+  backoffLimit: 4
+  serviceAccount:
+    create: true
+    name: ""
+  timeout: 2m
+  interval: 5s
+
+certManager:
+  enabled: false

--- a/pkg/controller/capsule_controller.go
+++ b/pkg/controller/capsule_controller.go
@@ -186,13 +186,16 @@ func (r *CapsuleReconciler) SetupWithManager(mgr ctrl.Manager, logger logr.Logge
 		b = b.Owns(&vpav1.VerticalPodAutoscaler{})
 	}
 
+	if r.Config.Certmanager != nil && r.Config.Certmanager.ClusterIssuer != "" {
+		b = b.Owns(&cmv1.Certificate{})
+	}
+
 	return b.
 		For(&v1alpha2.Capsule{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&v1.Service{}).
 		Owns(&netv1.Ingress{}).
 		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
-		Owns(&cmv1.Certificate{}).
 		Owns(&batchv1.CronJob{}).
 		Watches(
 			&v1.ConfigMap{},


### PR DESCRIPTION
- 🐛 certgen: Fix missing time on issued certificate.
- ♻️ certgen: make generated certificate comply with the
  kubernetes.io/tls secret type.
- 🚚 certgen: rename `patch-webhook-config` to just be `patch`
- ✨ chart rig-operator: add certgen job for when cert-manager is
  disabled.
- 🐛 rig-operator: could not start when cert-manager CRDs weren't
  installed.