### PR TITLE
✨ Publish rig CLI as docker image

### DIFF
--- a/build/package/goreleaser/goreleaser.yml
+++ b/build/package/goreleaser/goreleaser.yml
@@ -217,6 +217,21 @@ dockers:
     build_flag_templates:
       - "--platform=linux/arm64"
 
+  - image_templates:
+      - "ghcr.io/rigdev/rig:{{ .Version }}-amd64"
+    goarch: amd64
+    dockerfile: build/package/goreleaser/rig.Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  - image_templates:
+      - "ghcr.io/rigdev/rig:{{ .Version }}-arm64"
+    goarch: arm64
+    dockerfile: build/package/goreleaser/rig.Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64"
+
 docker_manifests:
   - name_template: "ghcr.io/rigdev/rig-operator:latest"
     image_templates:
@@ -234,6 +249,23 @@ docker_manifests:
     image_templates:
       - "ghcr.io/rigdev/rig-operator:{{ .Version }}-amd64"
       - "ghcr.io/rigdev/rig-operator:{{ .Version }}-arm64"
+
+  - name_template: "ghcr.io/rigdev/rig:latest"
+    image_templates:
+      - "ghcr.io/rigdev/rig:{{ .Version }}-amd64"
+      - "ghcr.io/rigdev/rig:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/rigdev/rig:{{ .Major }}"
+    image_templates:
+      - "ghcr.io/rigdev/rig:{{ .Version }}-amd64"
+      - "ghcr.io/rigdev/rig:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/rigdev/rig:{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/rigdev/rig:{{ .Version }}-amd64"
+      - "ghcr.io/rigdev/rig:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/rigdev/rig:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/rigdev/rig:{{ .Version }}-amd64"
+      - "ghcr.io/rigdev/rig:{{ .Version }}-arm64"
 
 changelog:
   sort: asc
@@ -270,5 +302,6 @@ release:
     name: rig
   prerelease: auto
   footer: |
-    ## Docker Image
+    ## Docker Images
     - `ghcr.io/rigdev/rig-operator:{{ .Version }}`
+    - `ghcr.io/rigdev/rig:{{ .Version }}`

--- a/build/package/goreleaser/rig.Dockerfile
+++ b/build/package/goreleaser/rig.Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.19.1 AS builder
+
+RUN apk add --no-cache ca-certificates && \
+    addgroup -g 1000 nonroot && \
+    adduser -u 1000 -G nonroot -D nonroot
+
+FROM alpine:3.19.1
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /etc/passwd /etc/passwd
+COPY rig /usr/local/bin/
+
+USER 1000
+
+CMD ["rig"]

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -361,5 +361,7 @@ tasks:
     deps: [tools:goreleaser, proto]
     cmds:
       - |
-        ./tools/bin/goreleaser build \
-          -f ./build/package/goreleaser/goreleaser.yml --snapshot --clean
+        ./tools/bin/goreleaser release \
+          -f ./build/package/goreleaser/goreleaser.yml \
+          --snapshot \
+          --clean


### PR DESCRIPTION
This adds goreleaser configuration for publishing the `rig` CLI as a
docker image.
