### PR TITLE
🐛 Fix goreleaser config

### DIFF
--- a/build/package/goreleaser/Dockerfile
+++ b/build/package/goreleaser/Dockerfile
@@ -14,7 +14,7 @@ COPY rigdev.init_container /usr/local/bin/plugin/
 COPY rigdev.object_template /usr/local/bin/plugin/
 COPY rigdev.annotations /usr/local/bin/plugin/
 COPY rigdev.datadog /usr/local/bin/plugin/
-COPY rigdev.google_sql_proxy /usr/local/bin/plugin/
+COPY rigdev.google_cloud_sql_auth_proxy /usr/local/bin/plugin/
 COPY rigdev.env_mapping /usr/local/bin/plugin/
 COPY rigdev.placement /usr/local/bin/plugin/
 COPY --from=builder /etc/passwd /etc/passwd

--- a/build/package/goreleaser/goreleaser.yml
+++ b/build/package/goreleaser/goreleaser.yml
@@ -122,9 +122,9 @@ builds:
       - -X github.com/rigdev/rig/pkg/build.version={{ .Version }}
       - -X github.com/rigdev/rig/pkg/build.commit={{ .Commit }}
       - -X github.com/rigdev/rig/pkg/build.date={{ .Date }}
-  - id: plugin/rigdev.google_sql_proxy
-    binary: plugin/rigdev.google_sql_proxy
-    main: ./plugins/google_sql_proxy
+  - id: plugin/rigdev.google_cloud_sql_auth_proxy
+    binary: plugin/rigdev.google_cloud_sql_auth_proxy
+    main: ./plugins/google_cloud_sql_auth_proxy
     env:
       - CGO_ENABLED=0
     goos:
@@ -181,6 +181,18 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+  - id: rig-ops
+    format: tar.gz
+    builds:
+      - rig-ops
+    name_template: >-
+      rig-ops_
+      {{- .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
+    format_overrides:
+      - goos: windows
+        format: zip
   - id: rig-operator
     format: tar.gz
     builds:
@@ -190,7 +202,7 @@ archives:
       - plugin/rigdev.object_template
       - plugin/rigdev.annotations
       - plugin/rigdev.datadog
-      - plugin/rigdev.google_sql_proxy
+      - plugin/rigdev.google_cloud_sql_auth_proxy
       - plugin/rigdev.env_mapping
     name_template: >-
       rig-operator_


### PR DESCRIPTION
- Rename of google_sql_proxy -> google_cloud_sql_auth_proxy
- Fix release of rig-ops binary: missing archive generation
