### PR TITLE
🐛 Ensure we have a homedir for rig CLI

### DIFF
--- a/build/package/goreleaser/rig.Dockerfile
+++ b/build/package/goreleaser/rig.Dockerfile
@@ -4,10 +4,6 @@ RUN apk add --no-cache ca-certificates && \
     addgroup -g 1000 nonroot && \
     adduser -u 1000 -G nonroot -D nonroot
 
-FROM alpine:3.19.1
-
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /etc/passwd /etc/passwd
 COPY rig /usr/local/bin/
 
 USER 1000


### PR DESCRIPTION
Previously we did a staged docker build which resulted in the home
directory for the nonroot user not existing.
