### PR TITLE
:recycle: Refactor capsule request to be ready for a project reconciler

### DIFF
--- a/pkg/controller/capsule_controller.go
+++ b/pkg/controller/capsule_controller.go
@@ -55,7 +55,7 @@ type CapsuleReconciler struct {
 	Config              *configv1alpha1.OperatorConfig
 	ClientSet           clientset.Interface
 	CapabilitiesService capabilities.Service
-	Pipeline            *pipeline.Pipeline
+	Pipeline            *pipeline.CapsulePipeline
 	PluginManager       *plugin.Manager
 }
 
@@ -79,8 +79,7 @@ const (
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *CapsuleReconciler) SetupWithManager(mgr ctrl.Manager, logger logr.Logger) error {
-	// TODO Where to get the context from?
-	ctx := context.Background()
+	ctx := context.TODO()
 
 	if err := mgr.GetFieldIndexer().IndexField(
 		context.Background(),
@@ -164,7 +163,7 @@ func (r *CapsuleReconciler) SetupWithManager(mgr ctrl.Manager, logger logr.Logge
 		return err
 	}
 
-	r.Pipeline = pipeline.New(r.Client, r.Client, r.Config, r.Scheme, logger)
+	r.Pipeline = pipeline.NewCapsulePipeline(r.Client, r.Client, r.Config, r.Scheme, logger)
 	for _, step := range steps {
 		r.Pipeline.AddStep(step)
 	}
@@ -351,13 +350,13 @@ func GetDefaultPipelineSteps(
 	ctx context.Context,
 	capSvc capabilities.Service,
 	cfg *v1alpha1.OperatorConfig,
-) ([]pipeline.Step, error) {
+) ([]pipeline.CapsuleStep, error) {
 	capabilities, err := capSvc.Get(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	var steps []pipeline.Step
+	var steps []pipeline.CapsuleStep
 
 	steps = append(steps,
 		NewServiceAccountStep(),

--- a/pkg/controller/deployment_step_test.go
+++ b/pkg/controller/deployment_step_test.go
@@ -39,8 +39,9 @@ func TestReusePodSelectors(t *testing.T) {
 	r := roclient.NewReader(scheme.New())
 	require.NoError(t, r.AddObject(current))
 
-	p := pipeline.New(nil, r, &v1alpha1.OperatorConfig{}, scheme.New(), logr.Discard())
-	req := pipeline.NewCapsuleRequest(p, &v1alpha2.Capsule{ObjectMeta: v1.ObjectMeta{
+	p := pipeline.NewCapsulePipeline(nil, r, &v1alpha1.OperatorConfig{}, scheme.New(), logr.Discard())
+	p.AddStep(NewDeploymentStep())
+	c := &v1alpha2.Capsule{ObjectMeta: v1.ObjectMeta{
 		Name:      "foobar",
 		Namespace: "my-ns",
 	}, Status: &v1alpha2.CapsuleStatus{
@@ -53,16 +54,14 @@ func TestReusePodSelectors(t *testing.T) {
 				},
 			},
 		},
-	}})
-
-	s := NewDeploymentStep()
-	p.AddStep(s)
-	_, err := p.RunSteps(context.Background(), req, false)
+	}}
+	res, err := p.RunCapsule(context.Background(), c)
 	require.NoError(t, err)
-
-	dep := &appsv1.Deployment{}
-	require.NoError(t, req.GetNew(dep))
-	require.Equal(t, map[string]string{
-		"app.kubernetes.io/name": "foobar",
-	}, dep.Spec.Selector.MatchLabels)
+	for _, o := range res.OutputObjects {
+		if dep, ok := o.Object.(*appsv1.Deployment); ok {
+			require.Equal(t, map[string]string{
+				"app.kubernetes.io/name": "foobar",
+			}, dep.Spec.Selector.MatchLabels)
+		}
+	}
 }

--- a/pkg/controller/pipeline/capsule_request_test.go
+++ b/pkg/controller/pipeline/capsule_request_test.go
@@ -23,7 +23,7 @@ func preparePipelineTest(t *testing.T, opts ...CapsuleRequestOption) (
 	cc := mockclient.NewMockClient(t)
 	ctx := context.Background()
 
-	p := New(cc, cc, &v1alpha1.OperatorConfig{}, scheme, logr.Discard())
+	p := NewCapsulePipeline(cc, cc, &v1alpha1.OperatorConfig{}, scheme, logr.Discard())
 	c := newCapsuleRequest(p, &v1alpha2.Capsule{}, opts...)
 
 	return ctx, cc, c
@@ -42,7 +42,7 @@ func TestOverrideUntrackedWithForceGivesAborted(t *testing.T) {
 	cc.EXPECT().Get(ctx, client.ObjectKey{Name: sa.GetName()}, &v1.ServiceAccount{}).
 		Return(nil)
 
-	_, err := c.commit(ctx)
+	_, err := c.Commit(ctx)
 	require.EqualError(t, err, "aborted: object exists but not in capsule status")
 }
 
@@ -59,10 +59,10 @@ func TestOverrideUntrackedWithoutForceGivesNoop(t *testing.T) {
 	cc.EXPECT().Get(ctx, client.ObjectKey{Name: sa.GetName()}, &v1.ServiceAccount{}).
 		Return(nil)
 
-	cs, err := c.commit(ctx)
+	cs, err := c.Commit(ctx)
 	require.NoError(t, err)
 
-	require.Equal(t, map[objectKey]*change{
+	require.Equal(t, map[ObjectKey]*Change{
 		{ObjectKey: client.ObjectKeyFromObject(sa), GroupVersionKind: CoreServiceAccount}: {
 			state: ResourceStateAlreadyExists,
 		},

--- a/pkg/controller/pipeline/request.go
+++ b/pkg/controller/pipeline/request.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+//nolint:lll
 type Request interface {
 	// Scheme returns the serialization scheme used by the rig operator.
 	// It contains all the types used by a Capsule.

--- a/pkg/controller/pipeline/request.go
+++ b/pkg/controller/pipeline/request.go
@@ -1,0 +1,402 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	configv1alpha1 "github.com/rigdev/rig/pkg/api/config/v1alpha1"
+	"github.com/rigdev/rig/pkg/errors"
+	"golang.org/x/exp/maps"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+type Request interface {
+	// Scheme returns the serialization scheme used by the rig operator.
+	// It contains all the types used by a Capsule.
+	Scheme() *runtime.Scheme
+	// Reader is a Kubernetes reader with access to the cluster the rig operator is running in.
+	Reader() client.Reader
+	// GetExisting populates 'obj' with a copy of the corresponding object owned by the capsule currently present in the cluster.
+	// If the name of 'obj' isn't set, it defaults to the Capsule name.
+	GetExisting(obj client.Object) error
+	// GetNew populates 'obj' with a copy of the corresponding object owned by the capsule about to be applied.
+	// If the name of 'obj' isn't set, it defaults to the Capsule name.
+	GetNew(obj client.Object) error
+	// Set updates the object recorded to be applied.
+	// If the name of 'obj' isn't set, it defaults to the Capsule name.
+	Set(obj client.Object) error
+	// Delete records the given object to be deleted.
+	// The behaviour is such that that calling
+	// req.Delete(obj) and then req.GetNew(obj)
+	// returns a not-found error from GetNew.
+	// If an object of the given type and name is present in the cluster, calling req.GetExisting(obj) succeds
+	// as calls to Delete (or Set) will only be applied to the cluster at the very end.
+	// If the name of 'obj' isn't set, it defaults to the Capsule name.
+	Delete(obj client.Object) error
+}
+
+type RequestDeps struct {
+	client client.Client
+	reader client.Reader
+	config *configv1alpha1.OperatorConfig
+	scheme *runtime.Scheme
+	logger logr.Logger
+}
+
+// TODO Make generic over object?
+type RequestState struct {
+	requestObject      client.Object
+	existingObjects    map[ObjectKey]client.Object
+	newObjects         map[ObjectKey]*Object
+	observedGeneration int64
+	dryRun             bool
+	force              bool
+}
+
+type RequestStrategies interface {
+	// Status updating strategies
+	UpdateStatusWithChanges(ctx context.Context, changes map[ObjectKey]*Change) error
+	UpdateStatusWithError(ctx context.Context, err error) error
+
+	// Execution loop strategies
+	LoadExistingObjects(ctx context.Context) error
+	Prepare()
+	OwnedLabel() string
+
+	GetKey(obj client.Object) (ObjectKey, error)
+}
+
+type RequestBase struct {
+	RequestDeps
+	RequestState
+	Strategies RequestStrategies
+}
+
+func NewRequestBase(
+	c client.Client,
+	reader client.Reader,
+	config *configv1alpha1.OperatorConfig,
+	scheme *runtime.Scheme,
+	logger logr.Logger,
+	strategies RequestStrategies,
+	object client.Object,
+) RequestBase {
+	return RequestBase{
+		RequestDeps: RequestDeps{
+			client: c,
+			reader: reader,
+			config: config,
+			scheme: scheme,
+			logger: logger,
+		},
+		RequestState: RequestState{
+			existingObjects: map[ObjectKey]client.Object{},
+			newObjects:      map[ObjectKey]*Object{},
+			requestObject:   object,
+		},
+		Strategies: strategies,
+	}
+}
+
+func (r *RequestBase) Scheme() *runtime.Scheme {
+	return r.scheme
+}
+
+func (r *RequestBase) Reader() client.Reader {
+	return r.reader
+}
+
+func (r *RequestBase) GetExisting(obj client.Object) error {
+	key, err := r.Strategies.GetKey(obj)
+	if err != nil {
+		return err
+	}
+
+	o, ok := r.newObjects[key]
+	if !ok {
+		return errors.NotFoundErrorf("object '%v' of type '%v' not found", key.Name, key.GroupVersionKind)
+	}
+
+	if o.Current == nil {
+		return errors.NotFoundErrorf("object '%v' of type '%v' has no existing version", key.Name, key.GroupVersionKind)
+	}
+
+	return r.scheme.Converter().Convert(o.Current, obj, nil)
+}
+
+func (r *RequestBase) GetNew(obj client.Object) error {
+	key, err := r.Strategies.GetKey(obj)
+	if err != nil {
+		return err
+	}
+
+	o, ok := r.newObjects[key]
+	if !ok {
+		return errors.NotFoundErrorf("object '%v' of type '%v' not found", key.Name, key.GroupVersionKind)
+	}
+
+	if o.New == nil {
+		return errors.NotFoundErrorf("object '%v' of type '%v' has no new version", key.Name, key.GroupVersionKind)
+	}
+
+	return r.scheme.Converter().Convert(o.New, obj, nil)
+}
+
+func (r *RequestBase) Set(obj client.Object) error {
+	key, err := r.Strategies.GetKey(obj)
+	if err != nil {
+		return err
+	}
+
+	o, ok := r.newObjects[key]
+	if !ok {
+		o = &Object{}
+	}
+	o.New = obj
+	r.newObjects[key] = o
+	return nil
+}
+
+func (r *RequestBase) Delete(obj client.Object) error {
+	key, err := r.Strategies.GetKey(obj)
+	if err != nil {
+		return err
+	}
+
+	o, ok := r.newObjects[key]
+	if ok {
+		o.New = nil
+	}
+
+	return nil
+}
+
+func (r *RequestBase) Commit(ctx context.Context) (map[ObjectKey]*Change, error) {
+	allKeys := sortedKeys(maps.Keys(r.newObjects))
+
+	// Prepare all the new objects with default labels / owner refs.
+	for _, key := range allKeys {
+		cObj := r.newObjects[key]
+		if cObj.New == nil {
+			continue
+		}
+
+		cObj.New.GetObjectKind().SetGroupVersionKind(key.GroupVersionKind)
+		normalizeObject(key, cObj.New)
+
+		labels := cObj.New.GetLabels()
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		labels[r.Strategies.OwnedLabel()] = r.requestObject.GetName()
+		cObj.New.SetLabels(labels)
+
+		if err := controllerutil.SetControllerReference(r.requestObject, cObj.New, r.scheme); err != nil {
+			return nil, err
+		}
+	}
+
+	changes := map[ObjectKey]*Change{}
+
+	// Dry run to detect no-op vs create vs update.
+	for _, key := range allKeys {
+		cObj := r.newObjects[key]
+
+		if cObj.Current == nil {
+			materializedObj := cObj.New.DeepCopyObject().(client.Object)
+			if err := r.client.Create(ctx, materializedObj, client.DryRunAll); kerrors.IsConflict(err) {
+				return nil, errors.FailedPreconditionErrorf("new object version available for '%v'", key)
+			} else if kerrors.IsAlreadyExists(err) || kerrors.IsInvalid(err) {
+				o, newErr := r.scheme.New(key.GroupVersionKind)
+				if newErr != nil {
+					return nil, err
+				}
+
+				co := o.(client.Object)
+				if getErr := r.client.Get(ctx, key.ObjectKey, co); kerrors.IsNotFound(getErr) {
+					r.logger.Info("configuration is invalid", "object", key, "error", err)
+					return nil, err
+				} else if getErr != nil {
+					return nil, fmt.Errorf("could not get existing object: %w", getErr)
+				}
+
+				if r.force || IsOwnedBy(r.requestObject, co) {
+					r.logger.Info("object exists but not in status, retrying", "object", key)
+					r.existingObjects[key] = normalizeObject(key, co)
+					return nil, errors.AbortedErrorf("object exists but not in capsule status")
+				}
+
+				r.logger.Info("create object skipped, not owned by controller", "object", key)
+				changes[key] = &Change{state: ResourceStateAlreadyExists}
+				continue
+			} else if err != nil {
+				return nil, fmt.Errorf("could not render create to %s: %w", key, err)
+			}
+
+			cObj.Materialized = normalizeObject(key, materializedObj)
+
+			r.logger.Info("create object", "object", key)
+			changes[key] = &Change{state: ResourceStateCreated}
+			continue
+		}
+
+		if !(r.force || IsOwnedBy(r.requestObject, cObj.Current)) {
+			r.logger.Info("update object skipped, not owned by controller", "object", key)
+			changes[key] = &Change{state: ResourceStateAlreadyExists}
+			continue
+		}
+
+		if cObj.New == nil {
+			r.logger.Info("delete object", "object", key)
+			changes[key] = &Change{state: ResourceStateDeleted}
+			continue
+		}
+
+		materializedObj := cObj.New.DeepCopyObject().(client.Object)
+		materializedObj.GetObjectKind().SetGroupVersionKind(cObj.Current.GetObjectKind().GroupVersionKind())
+
+		// Dry run to fully materialize the new spec.
+		materializedObj.SetResourceVersion(cObj.Current.GetResourceVersion())
+		if r.force && r.dryRun {
+			// TODO: If just force, we probably need to delete and re-create. Let's explore workarounds.
+			materializedObj.SetOwnerReferences(cObj.Current.GetOwnerReferences())
+		}
+		r.logger.Info("generating materialized version", "object", key)
+		if err := r.client.Update(ctx, materializedObj, client.DryRunAll); kerrors.IsConflict(err) {
+			return nil, errors.FailedPreconditionErrorf("new object version available for '%v'", key)
+		} else if err != nil {
+			return nil, fmt.Errorf("could not render update to %s: %w", key, err)
+		}
+
+		if ObjectsEquals(cObj.Current, materializedObj) {
+			r.logger.Info("update object skipped, not changed", "object", key)
+			changes[key] = &Change{state: ResourceStateUnchanged}
+			continue
+		}
+
+		cObj.Materialized = normalizeObject(key, materializedObj)
+
+		r.logger.Info("update object", "object", key)
+		changes[key] = &Change{state: ResourceStateUpdated}
+	}
+
+	// Skip update if no changes.
+	if r.observedGeneration == r.requestObject.GetGeneration() {
+		r.logger.Info("already at generation", "generation", r.observedGeneration)
+		hasChanges := false
+		for _, change := range changes {
+			switch change.state {
+			case ResourceStateUpdated, ResourceStateCreated, ResourceStateDeleted:
+				hasChanges = true
+			}
+		}
+		if !hasChanges {
+			r.logger.Info("no changes to apply", "generation", r.observedGeneration)
+			return changes, nil
+		}
+	}
+
+	if r.dryRun {
+		return changes, nil
+	}
+
+	if err := r.Strategies.UpdateStatusWithChanges(ctx, changes); err != nil {
+		return nil, err
+	}
+
+	var errs []error
+	for _, key := range sortedKeys(maps.Keys(changes)) {
+		change := changes[key]
+		if err := r.applyChange(ctx, key, change.state); err != nil {
+			change.err = err
+			errs = append(errs, err)
+		} else {
+			change.applied = true
+		}
+	}
+
+	if err := errors.Join(errs...); err != nil {
+		return nil, err
+	}
+
+	r.observedGeneration = r.requestObject.GetGeneration()
+	if err := r.Strategies.UpdateStatusWithChanges(ctx, changes); err != nil {
+		return nil, err
+	}
+
+	return changes, nil
+}
+
+func (r *RequestBase) applyChange(ctx context.Context, key ObjectKey, state ResourceState) error {
+	switch state {
+	case ResourceStateUpdated:
+		r.logger.Info("update object", "object", key)
+		obj := r.newObjects[key]
+		obj.New.SetResourceVersion(obj.Current.GetResourceVersion())
+		if err := r.client.Update(ctx, obj.New); err != nil {
+			return fmt.Errorf("could not update %s: %w", key.GroupVersionKind, err)
+		}
+
+	case ResourceStateCreated:
+		r.logger.Info("create object", "object", key)
+		obj := r.newObjects[key]
+		if err := r.client.Create(ctx, obj.New); err != nil {
+			return fmt.Errorf("could not create %s: %w", key.GroupVersionKind, err)
+		}
+
+	case ResourceStateDeleted:
+		r.logger.Info("delete object", "object", key)
+		obj := r.newObjects[key]
+		if err := r.client.Delete(ctx, obj.Current); err != nil {
+			return fmt.Errorf("could not update %s: %w", key.GroupVersionKind, err)
+		}
+	}
+
+	return nil
+}
+
+func normalizeObject(key ObjectKey, obj client.Object) client.Object {
+	obj.SetManagedFields(nil)
+	obj.GetObjectKind().SetGroupVersionKind(key.GroupVersionKind)
+	return obj
+}
+
+type Change struct {
+	state   ResourceState
+	applied bool
+	err     error
+}
+
+type ResourceState string
+
+const (
+	ResourceStateDeleted       ResourceState = "deleted"
+	ResourceStateUpdated       ResourceState = "updated"
+	ResourceStateUnchanged     ResourceState = "unchanged"
+	ResourceStateCreated       ResourceState = "created"
+	ResourceStateFailed        ResourceState = "failed"
+	ResourceStateAlreadyExists ResourceState = "alreadyExists"
+	ResourceStateChangePending ResourceState = "changePending"
+)
+
+func (r *RequestBase) PrepareRequest() *Result {
+	result := &Result{}
+	r.newObjects = map[ObjectKey]*Object{}
+	for _, k := range sortedKeys(maps.Keys(r.existingObjects)) {
+		o := r.existingObjects[k]
+		r.newObjects[k] = &Object{
+			Current: o.DeepCopyObject().(client.Object),
+		}
+		oo := o.DeepCopyObject()
+		oo.GetObjectKind().SetGroupVersionKind(k.GroupVersionKind)
+		result.InputObjects = append(result.InputObjects, oo.(client.Object))
+	}
+
+	r.Strategies.Prepare()
+
+	return result
+}

--- a/pkg/controller/pipeline/step.go
+++ b/pkg/controller/pipeline/step.go
@@ -2,6 +2,6 @@ package pipeline
 
 import "context"
 
-type Step interface {
+type CapsuleStep interface {
 	Apply(ctx context.Context, req CapsuleRequest) error
 }

--- a/pkg/service/pipeline/service.go
+++ b/pkg/service/pipeline/service.go
@@ -84,7 +84,7 @@ func (s *service) DryRun(
 		return nil, err
 	}
 
-	p := pipeline.New(s.client, s.client, cfg, scheme.New(), s.logger)
+	p := pipeline.NewCapsulePipeline(s.client, s.client, cfg, scheme.New(), s.logger)
 	for _, step := range steps {
 		p.AddStep(step)
 	}

--- a/plugins/annotations/plugin_test.go
+++ b/plugins/annotations/plugin_test.go
@@ -90,7 +90,7 @@ annotations:
 		t.Run(tt.name, func(t *testing.T) {
 			tt.capsule.Namespace = namespace
 			tt.capsule.Name = name
-			p := pipeline.New(nil, nil, nil, scheme.New(), logr.FromContextOrDiscard(context.Background()))
+			p := pipeline.NewCapsulePipeline(nil, nil, nil, scheme.New(), logr.FromContextOrDiscard(context.Background()))
 			req := pipeline.NewCapsuleRequest(p, tt.capsule)
 			assert.NoError(t, req.Set(&appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{

--- a/plugins/datadog/plugin_test.go
+++ b/plugins/datadog/plugin_test.go
@@ -90,7 +90,7 @@ unifiedServiceTags:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := pipeline.New(nil, nil, nil, scheme.New(), logr.FromContextOrDiscard(context.Background()))
+			p := pipeline.NewCapsulePipeline(nil, nil, nil, scheme.New(), logr.FromContextOrDiscard(context.Background()))
 			req := pipeline.NewCapsuleRequest(p, &v1alpha2.Capsule{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,

--- a/plugins/google_cloud_sql_auth_proxy/plugin_test.go
+++ b/plugins/google_cloud_sql_auth_proxy/plugin_test.go
@@ -177,7 +177,7 @@ files:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := pipeline.New(nil, nil, nil, scheme.New(), logr.FromContextOrDiscard(context.Background()))
+			p := pipeline.NewCapsulePipeline(nil, nil, nil, scheme.New(), logr.FromContextOrDiscard(context.Background()))
 			req := pipeline.NewCapsuleRequest(p, &v1alpha2.Capsule{ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,

--- a/plugins/object_template/plugin_test.go
+++ b/plugins/object_template/plugin_test.go
@@ -131,7 +131,7 @@ object: |
 		t.Run(tt.name, func(t *testing.T) {
 			tt.capsule.Namespace = namespace
 			tt.capsule.Name = name
-			p := pipeline.New(nil, nil, nil, scheme.New(), logr.FromContextOrDiscard(context.Background()))
+			p := pipeline.NewCapsulePipeline(nil, nil, nil, scheme.New(), logr.FromContextOrDiscard(context.Background()))
 			req := pipeline.NewCapsuleRequest(p, tt.capsule)
 			assert.NoError(t, req.Set(tt.current))
 

--- a/plugins/placement/plugin_test.go
+++ b/plugins/placement/plugin_test.go
@@ -96,7 +96,7 @@ requireTag: true`,
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := pipeline.New(nil, nil, nil, scheme.New(), logr.FromContextOrDiscard(context.Background()))
+			p := pipeline.NewCapsulePipeline(nil, nil, nil, scheme.New(), logr.FromContextOrDiscard(context.Background()))
 			if tt.annotations == nil {
 				tt.annotations = map[string]string{}
 			}


### PR DESCRIPTION
We want to reuse the commit-logic from the capsule request for the
project CRD. The abstraction extracted is not the nicest, but it'll
do for now.
