### PR TITLE
:bug: Skip PR deploy for dependabot PRs

### DIFF
--- a/.github/workflows/pr-update-docs.yml
+++ b/.github/workflows/pr-update-docs.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Dependabot does not have access to secrets, so no reason to try to
deploy these PRs.
