### PR TITLE
🚚 Add alias for `rig-ops plugins list`

### DIFF
--- a/cmd/rig-ops/cmd/plugins/setup.go
+++ b/cmd/rig-ops/cmd/plugins/setup.go
@@ -46,6 +46,7 @@ func initCmd(c Cmd) {
 func Setup(parent *cobra.Command, s *cli.SetupContext) {
 	pluginsCmd := &cobra.Command{
 		Use:               "plugins",
+		Aliases:           []string{"mods"},
 		Short:             "Migrate you kubernetes deployments to Rig Capsules",
 		PersistentPreRunE: s.MakeInvokePreRunE(initCmd),
 	}


### PR DESCRIPTION
We will be renaming plugins to mods soon. This is a small first step
which simply makes `mods` be an alias of plugins in the `rig-ops` CLI.

This will be featured on the new website content we are working on.
