### PR TITLE
:sparkles: Endpoint to get the difference between to environments in terms of changes

### DIFF
--- a/docs/docs/api/platform-api.md
+++ b/docs/docs/api/platform-api.md
@@ -89,6 +89,7 @@
 | /api.v1.capsule.Service/GetRolloutOfRevisions | [GetRolloutOfRevisionsRequest](#api-v1-capsule-GetRolloutOfRevisionsRequest) | [GetRolloutOfRevisionsResponse](#api-v1-capsule-GetRolloutOfRevisionsResponse) |  |
 | /api.v1.capsule.Service/WatchStatus | [WatchStatusRequest](#api-v1-capsule-WatchStatusRequest) | [WatchStatusResponse](#api-v1-capsule-WatchStatusResponse) stream | Stream the status of a capsule. |
 | /api.v1.capsule.Service/GetEffectiveGitSettings | [GetEffectiveGitSettingsRequest](#api-v1-capsule-GetEffectiveGitSettingsRequest) | [GetEffectiveGitSettingsResponse](#api-v1-capsule-GetEffectiveGitSettingsResponse) |  |
+| /api.v1.capsule.Service/GetEnvironmentDifferences | [GetEnvironmentDifferencesRequest](#api-v1-capsule-GetEnvironmentDifferencesRequest) | [GetEnvironmentDifferencesResponse](#api-v1-capsule-GetEnvironmentDifferencesResponse) | Experimental: Get Environment differences between two environment in terms of capsule changes. This can be used with a subsequent deploy to promote a capsule from one environment to another. |
 
 
 
@@ -5368,6 +5369,39 @@ Response to getting custom metrics for a capsule in an environment.
 | ----- | ---- | ----- | ----------- |
 | git | [model.GitStore](#model-GitStore) |  |  |
 | environment_enabled | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="api-v1-capsule-GetEnvironmentDifferencesRequest"></a>
+
+### GetEnvironmentDifferencesRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| capsule_id | [string](#string) |  | The capsule to promote. |
+| project_id | [string](#string) |  | The project in which the capsule lives. |
+| from_environment | [string](#string) |  | The environment to promote from |
+| to_environment | [string](#string) |  | The environment to promote to |
+
+
+
+
+
+
+<a name="api-v1-capsule-GetEnvironmentDifferencesResponse"></a>
+
+### GetEnvironmentDifferencesResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| changes | [Change](#api-v1-capsule-Change) | repeated | The changes between the environments |
 
 
 

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/nyaruka/phonenumbers v1.1.7
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.70.0
-	github.com/rigdev/rig-go-api v0.0.0-20240620080059-05fe42b53fab
+	github.com/rigdev/rig-go-api v0.0.0-20240621112655-8245aea89663
 	github.com/rigdev/rig-go-sdk v0.0.0-20240612092526-69df8621bc22
 	github.com/rivo/tview v0.0.0-20240524063012-037df494fb76
 	github.com/robfig/cron v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -272,8 +272,8 @@ github.com/prometheus/common v0.53.0 h1:U2pL9w9nmJwJDa4qqLQ3ZaePJ6ZTwt7cMD3AG3+a
 github.com/prometheus/common v0.53.0/go.mod h1:BrxBKv3FWBIGXw89Mg1AeBq7FSyRzXWI3l3e7W3RN5U=
 github.com/prometheus/procfs v0.14.0 h1:Lw4VdGGoKEZilJsayHf0B+9YgLGREba2C6xr+Fdfq6s=
 github.com/prometheus/procfs v0.14.0/go.mod h1:XL+Iwz8k8ZabyZfMFHPiilCniixqQarAy5Mu67pHlNQ=
-github.com/rigdev/rig-go-api v0.0.0-20240620080059-05fe42b53fab h1:wU2w0VAoxwbxGDbPdePhzve7tzgZzssBHuOGbfnCB08=
-github.com/rigdev/rig-go-api v0.0.0-20240620080059-05fe42b53fab/go.mod h1:S/o6zMsrLQKoEn3PCJ2IuN4aEIMGoN7jD13IGmaCBUg=
+github.com/rigdev/rig-go-api v0.0.0-20240621112655-8245aea89663 h1:1FIfmcpKhJhufzunc6JWgmlfbt5SiqzA4KXbh7mStX0=
+github.com/rigdev/rig-go-api v0.0.0-20240621112655-8245aea89663/go.mod h1:S/o6zMsrLQKoEn3PCJ2IuN4aEIMGoN7jD13IGmaCBUg=
 github.com/rigdev/rig-go-sdk v0.0.0-20240612092526-69df8621bc22 h1:NFjBY/F42lcgqnqru+h1q3RrzRk645HUilCvbZD7exI=
 github.com/rigdev/rig-go-sdk v0.0.0-20240612092526-69df8621bc22/go.mod h1:bmASl5RyuOoEddGeaOxHB27W3KDI4sBxqfnR1cRTstY=
 github.com/rivo/tview v0.0.0-20240524063012-037df494fb76 h1:iqvDlgyjmqleATtFbA7c14djmPh2n4mCYUv7JlD/ruA=

--- a/proto/rig/api/v1/capsule/service.proto
+++ b/proto/rig/api/v1/capsule/service.proto
@@ -100,6 +100,27 @@ service Service {
 
   rpc GetEffectiveGitSettings(GetEffectiveGitSettingsRequest)
       returns (GetEffectiveGitSettingsResponse) {}
+  // Experimental: Get Environment differences between two environment in terms
+  // of capsule changes. This can be used with a subsequent deploy to promote a
+  // capsule from one environment to another.
+  rpc GetEnvironmentDifferences(GetEnvironmentDifferencesRequest)
+      returns (GetEnvironmentDifferencesResponse) {}
+}
+
+message GetEnvironmentDifferencesRequest {
+  // The capsule to promote.
+  string capsule_id = 1;
+  // The project in which the capsule lives.
+  string project_id = 2;
+  // The environment to promote from
+  string from_environment = 3;
+  // The environment to promote to
+  string to_environment = 4;
+}
+
+message GetEnvironmentDifferencesResponse {
+  // The changes between the environments
+  repeated api.v1.capsule.Change changes = 1;
 }
 
 message WatchRolloutsRequest {


### PR DESCRIPTION
**PromotionV1 Proposal:**

- A Simple “GetEnvironmentDifferences” endpoint, that computes the difference between two specs.
- Can be used to promote with a subsequent deploy of changes -+ changes.
- In the dashboard, we get the differences and open the configuration modal.
