### PR TITLE
🐛 Fix reading of instance image ID (ImageID in favor of Image)

### DIFF
--- a/plugins/capsulesteps/deployment/watcher.go
+++ b/plugins/capsulesteps/deployment/watcher.go
@@ -259,8 +259,8 @@ func makeImagePullingCondition(container containerInfo) {
 		}
 	}
 
-	container.platformStatus.Image = container.status.Image
-	container.subObj.Properties["Image"] = container.status.Image
+	container.platformStatus.Image = container.status.ImageID
+	container.subObj.Properties["Image"] = container.status.ImageID
 	container.subObj.Conditions = append(container.subObj.Conditions, cond)
 }
 


### PR DESCRIPTION
It turns out ImageID is the canonizal digested image path, where Image is some internal product (just a SHA when digests are used).