### PR TITLE
✨ Change platform config format for Git clients

### DIFF
--- a/docs/docs/api/config/v1alpha1.md
+++ b/docs/docs/api/config/v1alpha1.md
@@ -116,8 +116,8 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `auths` _[GitAuth](#gitauth) array_ | Auths the git client can behave as. |
-| `gitHubAuths` _[GitHub](#github) array_ | GitHubAuths is authentication information for GitHub repositories |
-| `gitLabAuths` _[GitLab](#gitlab) array_ |  |
+| `gitHubAuths` _[GitHub](#github) array_ | GitHubAuths is authentication information for GitHub repositories. |
+| `gitLabAuths` _[GitLab](#gitlab) array_ | GitLabAuths is the authentication information for GitLab repositories. |
 | `author` _[GitAuthor](#gitauthor)_ | Author used when creating commits. |
 
 
@@ -353,7 +353,8 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `url` _string_ | URL is a exact match for the repo-url this auth can be used for. |
-| `urlPrefix` _string_ | URLPrefix is a prefix-match for the repo urls this auth can be used for. |
+| `urlPrefix` _string_ | URLPrefix is a prefix-match for the repo urls this auth can be used for.<br />Deprecated; use Match instead |
+| `match` _[URLMatch](#urlmatch)_ | How the url should be matched. Can either be 'exact' or 'prefix'<br />Defaults to 'exact' |
 | `credentials` _[GitCredentials](#gitcredentials)_ | Credentials to use when connecting to git. |
 | `pullingIntervalSeconds` _integer_ | If no web hook is confugured, pull the git repository at the set interval instead<br />to fetch changes. Defaults to 3 mins if no value. |
 
@@ -408,8 +409,9 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `organization` _string_ | Organization is the GitHub organization to match. |
-| `repository` _string_ | Repository matches the GitHub repository. If empty, matches all. |
+| `orgRepo` _string_ | OrgRepo is a string containing the GitHub organization and optionally a repository as well.<br />If both org and repo is given, they should be seperated by a '/', e.g. 'myorg/myrepo'.<br />If repo is not given, e.g. 'myrepo', then it matches all repositories within the org 'myorg'.<br />If both org and repo is given, it matches exactly the repo within the org. |
+| `organization` _string_ | Organization is the GitHub organization to match.<br />Deprecated. Use OrgRepo instead |
+| `repository` _string_ | Repository matches the GitHub repository. If empty, matches all.<br />Deprecated. Use OrgRepo instead |
 | `auth` _[GitHubAuth](#githubauth)_ | Auth contains GitHub specific authentication configuration. |
 | `polling` _[GitHubPolling](#githubpolling)_ | Polling contains GitHub specific configuration. |
 
@@ -464,8 +466,9 @@ _Appears in:_
 
 | Field | Description |
 | --- | --- |
-| `groups` _string array_ | Groups is a sequence of GitLab groups.<br />The first is the main group and the rest a nesting of subgroups.<br />If Project is empty, the configuration will match any<br />GitLab repository whose (group, subgroups) sequence where 'groups' is a prefix. |
-| `project` _string_ | Project is the GitLab project of the repository. Can be empty for matching all project names. |
+| `groupsProject` _string_ | GroupsProject is a string containing a list of GitLab groups and optionally a project<br />Groups are separated by '/' and project by ':', e.g.<br />group/subgroup1/subgroup2:project<br />If a project is given, it matches exactly that project within that sequence of subsgroups<br />If no project is given, it matches all projects within all subgroups which are children of the<br />given group sequence. E.g.<br />'group' will match 'group/subgroup1:project1' and 'group/subgroup1/subgroup2:project2' |
+| `groups` _string array_ | Groups is a sequence of GitLab groups.<br />The first is the main group and the rest a nesting of subgroups.<br />If Project is empty, the configuration will match any<br />GitLab repository whose (group, subgroups) sequence where 'groups' is a prefix.<br />Deprecated. Use GroupsProject |
+| `project` _string_ | Project is the GitLab project of the repository. Can be empty for matching all project names.<br />Deprecated. Use GroupsProject |
 | `auth` _[GitLabAuth](#gitlabauth)_ | Auth contains GitLab specific authentication configuration. |
 | `polling` _[GitLabPolling](#gitlabpolling)_ | Polling contains GitLab specific configuration. |
 
@@ -745,6 +748,17 @@ _Appears in:_
 | `namespaces` _string array_ | If set, only capsules in one of the namespaces given will have this step run.<br />Deprecated, use Match.Namespaces. |
 | `capsules` _string array_ | If set, only execute the plugin on the capsules specified.<br />Deprecated, use Match.Names. |
 | `enableForPlatform` _boolean_ | If set, will enable the step for the Rig platform which is a Capsule as well<br />Deprecated, use Match.EnableForPlatform. |
+
+
+### URLMatch
+
+_Underlying type:_ _string_
+
+
+
+_Appears in:_
+- [GitAuth](#gitauth)
+
 
 
 

--- a/docs/docs/api/config/v1alpha1.md
+++ b/docs/docs/api/config/v1alpha1.md
@@ -353,7 +353,7 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `url` _string_ | URL is a exact match for the repo-url this auth can be used for. |
-| `urlPrefix` _string_ | URLPrefix is a prefix-match for the repo urls this auth can be used for.<br />Deprecated; use Match instead |
+| `urlPrefix` _string_ | URLPrefix is a prefix-match for the repo urls this auth can be used for.<br />Deprecated: use Match instead |
 | `match` _[URLMatch](#urlmatch)_ | How the url should be matched. Can either be 'exact' or 'prefix'<br />Defaults to 'exact' |
 | `credentials` _[GitCredentials](#gitcredentials)_ | Credentials to use when connecting to git. |
 | `pullingIntervalSeconds` _integer_ | If no web hook is confugured, pull the git repository at the set interval instead<br />to fetch changes. Defaults to 3 mins if no value. |
@@ -410,8 +410,8 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `orgRepo` _string_ | OrgRepo is a string containing the GitHub organization and optionally a repository as well.<br />If both org and repo is given, they should be seperated by a '/', e.g. 'myorg/myrepo'.<br />If repo is not given, e.g. 'myrepo', then it matches all repositories within the org 'myorg'.<br />If both org and repo is given, it matches exactly the repo within the org. |
-| `organization` _string_ | Organization is the GitHub organization to match.<br />Deprecated. Use OrgRepo instead |
-| `repository` _string_ | Repository matches the GitHub repository. If empty, matches all.<br />Deprecated. Use OrgRepo instead |
+| `organization` _string_ | Organization is the GitHub organization to match.<br />Deprecated: Use OrgRepo instead |
+| `repository` _string_ | Repository matches the GitHub repository. If empty, matches all.<br />Deprecated: Use OrgRepo instead |
 | `auth` _[GitHubAuth](#githubauth)_ | Auth contains GitHub specific authentication configuration. |
 | `polling` _[GitHubPolling](#githubpolling)_ | Polling contains GitHub specific configuration. |
 
@@ -467,8 +467,8 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `groupsProject` _string_ | GroupsProject is a string containing a list of GitLab groups and optionally a project<br />Groups are separated by '/' and project by ':', e.g.<br />group/subgroup1/subgroup2:project<br />If a project is given, it matches exactly that project within that sequence of subsgroups<br />If no project is given, it matches all projects within all subgroups which are children of the<br />given group sequence. E.g.<br />'group' will match 'group/subgroup1:project1' and 'group/subgroup1/subgroup2:project2' |
-| `groups` _string array_ | Groups is a sequence of GitLab groups.<br />The first is the main group and the rest a nesting of subgroups.<br />If Project is empty, the configuration will match any<br />GitLab repository whose (group, subgroups) sequence where 'groups' is a prefix.<br />Deprecated. Use GroupsProject |
-| `project` _string_ | Project is the GitLab project of the repository. Can be empty for matching all project names.<br />Deprecated. Use GroupsProject |
+| `groups` _string array_ | Groups is a sequence of GitLab groups.<br />The first is the main group and the rest a nesting of subgroups.<br />If Project is empty, the configuration will match any<br />GitLab repository whose (group, subgroups) sequence where 'groups' is a prefix.<br />Deprecated: Use GroupsProject |
+| `project` _string_ | Project is the GitLab project of the repository. Can be empty for matching all project names.<br />Deprecated: Use GroupsProject |
 | `auth` _[GitLabAuth](#gitlabauth)_ | Auth contains GitLab specific authentication configuration. |
 | `polling` _[GitLabPolling](#gitlabpolling)_ | Polling contains GitLab specific configuration. |
 

--- a/docs/docs/operator-manual/gitops.mdx
+++ b/docs/docs/operator-manual/gitops.mdx
@@ -86,13 +86,11 @@ rig:
               private_key: <pem-encoded-private-key>
       gitHubAuths:
         # Matches git@github.com:myorg/myrepository2.git and enables WebHook
-        - organization: myorg
-          repository: myrepository2
+        - orgRepo: myorg/myrepository2
           polling:
             webhookSecret: secret123
         # Matches https://github.com/myorg/myrepository3.git, uses GitHub authentication and pulls every 60 seconds.
-        - organization: myorg
-          repository: myrepository3
+        - orgRepo: myorg/myrepository3
           auth:
             appID: 1234
             installationID: 12345
@@ -101,11 +99,7 @@ rig:
             pullingIntervalSeconds: 60
       gitLabAuths
         # Matches git@gitlab.com:mygroup/subgroup1/subgroup2/myproject.git, uses GitLab authentication and enables WebHook.
-        - groups:
-            - mygroup
-            - subgroup1
-            - subgroup2
-          project: myproject
+        - groupsProject: mygroup/subgroup1/subgroup2:myproject
           auth:
             accessToken: MY_ACCESS_TOKEN
           polling:
@@ -119,7 +113,7 @@ When computing the configuration for a repository, Rig first searches the provid
 either polling or authentication sat, it will provide the missing configuration from the first matching general git config (in `client.git.auths`).
 
 #### GitHub Authentication
-[Here](/api/config/v1alpha1#github) you can see the definition of our GitHub configuration. The Organization and Repository uniquely defines a GitHub repository. We support GitHub specific authentication using [GitHub Apps](https://docs.github.com/en/apps).
+[Here](/api/config/v1alpha1#github) you can see the definition of our GitHub configuration. `OrgRepo` uniquely defines a GitHub repository. We support GitHub specific authentication using [GitHub Apps](https://docs.github.com/en/apps).
 You have to make a new GitHub App for either your organization or account. Go through `Settings` -> `Developer Settings` -> `GitHub Apps` -> `New GitHub App`. Give the App a name and HomePage URL (neither of which Rig uses but GitHub requires them). Under `Permissions` and `Repository Permissions`, you'll have to give the app Read/Write access to `Contents`.
 
 After creating the app, go back to the App overview page under `Developer Settings`. Click `Edit` for your newly created app, then Install App and choose your organization or user. After being installed, you can find the app under `Third-party Access` / `GitHub Apps`. Clicking `Configure` takes you to the installation page.

--- a/pkg/api/config/v1alpha1/platform_config_types.go
+++ b/pkg/api/config/v1alpha1/platform_config_types.go
@@ -370,7 +370,7 @@ type GitAuth struct {
 	URL string `json:"url,omitempty"`
 
 	// URLPrefix is a prefix-match for the repo urls this auth can be used for.
-	// Deprecated; use Match instead
+	// Deprecated: use Match instead
 	URLPrefix string `json:"urlPrefix,omitempty"`
 
 	// How the url should be matched. Can either be 'exact' or 'prefix'
@@ -408,11 +408,11 @@ type GitHub struct {
 	OrgRepo string `json:"orgRepo"`
 
 	// Organization is the GitHub organization to match.
-	// Deprecated. Use OrgRepo instead
+	// Deprecated: Use OrgRepo instead
 	Organization string `json:"organization"`
 
 	// Repository matches the GitHub repository. If empty, matches all.
-	// Deprecated. Use OrgRepo instead
+	// Deprecated: Use OrgRepo instead
 	Repository string `json:"repository,omitempty"`
 
 	// Auth contains GitHub specific authentication configuration.
@@ -484,11 +484,11 @@ type GitLab struct {
 	// The first is the main group and the rest a nesting of subgroups.
 	// If Project is empty, the configuration will match any
 	// GitLab repository whose (group, subgroups) sequence where 'groups' is a prefix.
-	// Deprecated. Use GroupsProject
+	// Deprecated: Use GroupsProject
 	Groups []string `json:"groups,omitempty"`
 
 	// Project is the GitLab project of the repository. Can be empty for matching all project names.
-	// Deprecated. Use GroupsProject
+	// Deprecated: Use GroupsProject
 	Project string `json:"project,omitempty"`
 
 	// Auth contains GitLab specific authentication configuration.

--- a/pkg/api/config/v1alpha1/platform_config_validate.go
+++ b/pkg/api/config/v1alpha1/platform_config_validate.go
@@ -1,0 +1,227 @@
+package v1alpha1
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/xeipuuv/gojsonschema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func (cfg *PlatformConfig) Validate() error {
+	if cfg.Cluster.Type != "" && len(cfg.Clusters) != 0 {
+		return fmt.Errorf("only one of `cluster` and `clusters` must be set")
+	}
+
+	var errs field.ErrorList
+	errs = append(errs, cfg.Cluster.validate(field.NewPath("clusters"))...)
+	errs = append(errs, cfg.validateCapsuleExtensions(field.NewPath("capsuleExtensions"))...)
+	errs = append(errs, cfg.Client.validate(field.NewPath("client"))...)
+
+	return errs.ToAggregate()
+}
+
+func (c Cluster) validate(path *field.Path) field.ErrorList {
+	return c.Git.validate(path.Child("git"))
+}
+
+func (g ClusterGit) validate(path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	if g.PathPrefix != "" && g.PathPrefixes != (PathPrefixes{}) {
+		return append(errs, field.Invalid(path, g, "can't set both `pathPrefix` and `pathPrefixes`"))
+	}
+
+	return errs
+}
+
+func (g Client) validate(path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	errs = append(errs, g.Git.validate(path.Child("git"))...)
+	return errs
+}
+
+func (g ClientGit) validate(path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	for idx, a := range g.Auths {
+		errs = append(errs, a.validate(path.Index(idx))...)
+	}
+	for idx, g := range g.GitHubAuths {
+		errs = append(errs, g.validate(path.Index(idx))...)
+	}
+	for idx, g := range g.GitLabAuths {
+		errs = append(errs, g.validate(path.Index(idx))...)
+	}
+	return errs
+}
+
+func (a GitAuth) validate(path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	if a.URL == "" && a.URLPrefix == "" {
+		errs = append(errs, field.Invalid(path, a, "either `url` or `urlPrefix` must be set"))
+	}
+	if a.URL != "" && a.URLPrefix != "" {
+		errs = append(errs, field.Invalid(path, a, "not both `url` and `urlPrefix` can be set"))
+	}
+	if a.URLPrefix != "" && a.Match != "" {
+		errs = append(errs, field.Invalid(path, a, "not both `urlPrefix` and `match` can be given"))
+	}
+	if !slices.Contains([]string{"", "exact", "prefix"}, string(a.Match)) {
+		errs = append(errs, field.Invalid(path.Child("match"), a.Match, "`match` must be one of '', 'exact' or 'prefix'"))
+	}
+	return errs
+}
+
+func (g GitHub) validate(path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	if g.OrgRepo != "" && (g.Organization != "" || g.Repository != "") {
+		errs = append(errs, field.Invalid(path, g, "not both 'orgRepo' and 'organization' or 'repository' can be given"))
+	}
+	if g.OrgRepo == "" && g.Organization == "" {
+		errs = append(errs, field.Invalid(path.Child("orgRepo"), g.OrgRepo, "'orgRepo' must be given"))
+	}
+
+	if g.OrgRepo != "" {
+		if !orgRepoRegex.MatchString(g.OrgRepo) {
+			errs = append(errs, field.Invalid(path.Child("orgRepo"), g.OrgRepo, "`orgRepo` is malformed"))
+		}
+	}
+	return errs
+}
+
+var orgRepoRegex = regexp.MustCompile("^[^/]+(/[^/]+)?$")
+
+func (g GitLab) validate(path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	if g.GroupsProject != "" && (len(g.Groups) != 0 || g.Project != "") {
+		errs = append(errs, field.Invalid(path, g, "not both `groupsProject` and `groups` or `project` can be given"))
+	}
+	if g.GroupsProject == "" && len(g.Groups) == 0 {
+		errs = append(errs, field.Invalid(path, g.GroupsProject, "`groupsProject` cannot be empty"))
+	}
+	if g.GroupsProject != "" {
+		if !groupsProjectRegex.MatchString(g.GroupsProject) {
+			errs = append(errs, field.Invalid(path, g.GroupsProject, "`groupsProject` is malformed"))
+		}
+	}
+	return errs
+}
+
+var groupsProjectRegex = regexp.MustCompile("^[^/:]+(/[^/:]+)*(:[^/:]+)?$")
+
+func (cfg *PlatformConfig) validateCapsuleExtensions(path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	for k, v := range cfg.CapsuleExtensions {
+		if err := v.validate(path.Key(k)); err != nil {
+			errs = append(errs, err...)
+		}
+	}
+	return errs
+}
+
+func (e Extension) validate(path *field.Path) field.ErrorList {
+	var errs field.ErrorList
+
+	schemaPath := path.Child("schema")
+	if e.Schema == nil {
+		errs = append(errs, field.Invalid(
+			path, e, "value has no schema"),
+		)
+		return errs
+	}
+	if e.Schema.Type != "object" {
+		errs = append(errs, field.Invalid(
+			schemaPath.Child("type"), e.Schema.Type, "top level schema must be of type 'object'"),
+		)
+		return errs
+	}
+
+	for key, prop := range e.Schema.Properties {
+		if prop.Type == "object" || prop.Type == "array" {
+			errs = append(errs,
+				field.Invalid(
+					schemaPath.Child("properties").Key(key).Child("type"),
+					prop.Type, "complex child properties are not yet supported"),
+			)
+		}
+	}
+
+	if _, err := gojsonschema.NewSchema(gojsonschema.NewGoLoader(e.Schema)); err != nil {
+		errs = append(errs, field.Invalid(schemaPath, e.Schema, err.Error()))
+	}
+
+	return errs
+}
+
+func (cfg *PlatformConfig) Migrate() {
+	for _, c := range cfg.Clusters {
+		if c.Git.URL != "" && c.Git.Credentials != (GitCredentials{}) {
+			cfg.Client.Git.Auths = append(cfg.Client.Git.Auths, GitAuth{
+				URL:         c.Git.URL,
+				Credentials: c.Git.Credentials,
+			})
+		}
+		if cfg.Client.Git.Author.Name == "" {
+			cfg.Client.Git.Author.Name = c.Git.Author.Name
+			cfg.Client.Git.Author.Email = c.Git.Author.Email
+		}
+	}
+
+	for idx, a := range cfg.Client.Git.Auths {
+		if a.URLPrefix != "" {
+			a.URL = a.URLPrefix
+			a.Match = URLMatchPrefix
+			a.URLPrefix = ""
+		}
+		if a.Match == "" {
+			a.Match = URLMatchExact
+		}
+		cfg.Client.Git.Auths[idx] = a
+	}
+
+	for idx, g := range cfg.Client.Git.GitHubAuths {
+		if g.Organization != "" {
+			g.OrgRepo = g.Organization
+			if g.Repository != "" {
+				g.OrgRepo += "/" + g.Repository
+			}
+		}
+		g.Organization = ""
+		g.Repository = ""
+		cfg.Client.Git.GitHubAuths[idx] = g
+	}
+
+	for idx, g := range cfg.Client.Git.GitLabAuths {
+		if len(g.Groups) > 0 {
+			g.GroupsProject = strings.Join(g.Groups, "/")
+		}
+		if g.Project != "" {
+			g.GroupsProject += ":" + g.Project
+		}
+		g.Groups = nil
+		g.Project = ""
+		cfg.Client.Git.GitLabAuths[idx] = g
+	}
+
+	if cfg.Client.Mailjet != (ClientMailjet{}) {
+		cfg.Client.Mailjets["mailjet"] = cfg.Client.Mailjet
+	}
+
+	if cfg.Client.SMTP != (ClientSMTP{}) {
+		cfg.Client.SMTPs["smtp"] = cfg.Client.SMTP
+	}
+
+	if cfg.Email != (Email{}) && cfg.Email.Type != "" {
+		switch cfg.Email.Type {
+		case EmailTypeMailjet:
+			if cfg.Email.ID == "" {
+				cfg.Email.ID = "mailjet"
+			}
+		case EmailTypeSMTP:
+			if cfg.Email.ID == "" {
+				cfg.Email.ID = "smtp"
+			}
+		}
+	}
+}

--- a/pkg/api/config/v1alpha1/platform_test.go
+++ b/pkg/api/config/v1alpha1/platform_test.go
@@ -1,0 +1,117 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlatformConfigValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *PlatformConfig
+		expectedErr string
+	}{
+		{
+			name: "invalid github orgRepo",
+			cfg: &PlatformConfig{
+				Client: Client{
+					Git: ClientGit{
+						GitHubAuths: []GitHub{{
+							OrgRepo: "myorg/myrepo/bad",
+						}},
+					},
+				},
+			},
+			expectedErr: "client.git[0].orgRepo: Invalid value: \"myorg/myrepo/bad\": `orgRepo` is malformed",
+		},
+		{
+			name: "another invalid github orgRepo",
+			cfg: &PlatformConfig{
+				Client: Client{
+					Git: ClientGit{
+						GitHubAuths: []GitHub{{
+							OrgRepo: "myorg/",
+						}},
+					},
+				},
+			},
+			expectedErr: "client.git[0].orgRepo: Invalid value: \"myorg/\": `orgRepo` is malformed",
+		},
+		{
+			name: "good github auth",
+			cfg: &PlatformConfig{
+				Client: Client{
+					Git: ClientGit{
+						GitHubAuths: []GitHub{{
+							OrgRepo: "myorg/myrepo",
+						}},
+					},
+				},
+			},
+		},
+		{
+			name: "another good github auth",
+			cfg: &PlatformConfig{
+				Client: Client{
+					Git: ClientGit{
+						GitHubAuths: []GitHub{{
+							OrgRepo: "myorg",
+						}},
+					},
+				},
+			},
+		},
+		{
+			name: "bad gitlab auth",
+			cfg: &PlatformConfig{
+				Client: Client{
+					Git: ClientGit{
+						GitLabAuths: []GitLab{{
+							GroupsProject: "group/subgroup1//subgroup2",
+						}},
+					},
+				},
+			},
+			expectedErr: "client.git[0]: Invalid value: \"group/subgroup1//subgroup2\": `groupsProject` is malformed",
+		},
+		{
+			name: "another bad gitlab auth",
+			cfg: &PlatformConfig{
+				Client: Client{
+					Git: ClientGit{
+						GitLabAuths: []GitLab{{
+							GroupsProject: "group/subgro:up1/subgroup2",
+						}},
+					},
+				},
+			},
+			expectedErr: "client.git[0]: Invalid value: \"group/subgro:up1/subgroup2\": `groupsProject` is malformed",
+		},
+		{
+			name: "good gitlab auths",
+			cfg: &PlatformConfig{
+				Client: Client{
+					Git: ClientGit{
+						GitLabAuths: []GitLab{
+							{GroupsProject: "group"},
+							{GroupsProject: "group/subgroup1/subgroup2"},
+							{GroupsProject: "group/subgroup1/subgroup2:project"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.expectedErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Equal(t, tt.expectedErr, err.Error())
+			}
+		})
+	}
+}

--- a/pkg/api/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/config/v1alpha1/zz_generated.deepcopy.go
@@ -142,8 +142,8 @@ func (in *ClientGit) DeepCopyInto(out *ClientGit) {
 		*out = make([]GitHub, len(*in))
 		copy(*out, *in)
 	}
-	if in.GiLabAuths != nil {
-		in, out := &in.GiLabAuths, &out.GiLabAuths
+	if in.GitLabAuths != nil {
+		in, out := &in.GitLabAuths, &out.GitLabAuths
 		*out = make([]GitLab, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])

--- a/pkg/service/config/config_test.go
+++ b/pkg/service/config/config_test.go
@@ -150,6 +150,140 @@ capsuleExtensions:
 				"capsuleExtensions[key].schema.type: Invalid value: \"string\": top level schema must be of type 'object'",
 			),
 		},
+		{
+			name: "git auths",
+			files: []string{
+				`apiVersion: config.rig.dev/v1alpha1
+kind: PlatformConfig
+port: 1234
+client:
+  git:
+    auths:
+    - url: https://github.com/myorg/myrepo2.git
+      credentials:
+        https:
+          username: myuser2
+    - url: https://github.com/myorg/myrepo.git
+      credentials:
+        https:
+          username: myuser
+    gitHubAuths:
+    - orgRepo: someorg/somerepo
+      polling:
+        webhookSecret: secret1
+    - orgRepo: someorg
+      polling:
+        webhookSecret: secret2
+    gitLabAuths:
+    - groupsProject: group/subgroup:project
+      auth:
+        accessToken: token1`,
+				`apiVersion: config.rig.dev/v1alpha1
+kind: PlatformConfig
+port: 1234
+client:
+  git:
+    auths:
+    - url: https://github.com/myorg/myrepo.git
+      credentials:
+        https:
+          password: mypass
+    gitHubAuths:
+    - orgRepo: someorg/somerepo
+      polling:
+        webhookSecret: secret3
+    - orgRepo: someotherorg
+      polling:
+        webhookSecret: secret4
+    gitLabAuths:
+    - groupsProject: group/subgroup:project
+      auth:
+        accessToken: token2
+    - groupsProject: group/subgroup
+      auth:
+        accessToken: token3`,
+			},
+			expected: &v1alpha1.PlatformConfig{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "PlatformConfig",
+					APIVersion: "config.rig.dev/v1alpha1",
+				},
+				Port:             1234,
+				TelemetryEnabled: true,
+				Client: v1alpha1.Client{
+					Mailjets: map[string]v1alpha1.ClientMailjet{},
+					SMTPs:    map[string]v1alpha1.ClientSMTP{},
+					Postgres: v1alpha1.ClientPostgres{
+						Port:     5432,
+						Database: "rig",
+					},
+					Operator: v1alpha1.ClientOperator{
+						BaseURL: "rig-operator:9000",
+					},
+					Git: v1alpha1.ClientGit{
+						Auths: []v1alpha1.GitAuth{
+							{
+								URL:   "https://github.com/myorg/myrepo2.git",
+								Match: "exact",
+								Credentials: v1alpha1.GitCredentials{
+									HTTPS: v1alpha1.HTTPSCredential{
+										Username: "myuser2",
+									},
+								},
+							},
+							{
+								URL:   "https://github.com/myorg/myrepo.git",
+								Match: "exact",
+								Credentials: v1alpha1.GitCredentials{
+									HTTPS: v1alpha1.HTTPSCredential{
+										Username: "myuser",
+										Password: "mypass",
+									},
+								},
+							},
+						},
+						GitHubAuths: []v1alpha1.GitHub{
+							{
+								OrgRepo: "someorg/somerepo",
+								Polling: v1alpha1.GitHubPolling{
+									WebhookSecret: "secret3",
+								},
+							},
+							{
+								OrgRepo: "someotherorg",
+								Polling: v1alpha1.GitHubPolling{
+									WebhookSecret: "secret4",
+								},
+							},
+							{
+								OrgRepo: "someorg",
+								Polling: v1alpha1.GitHubPolling{
+									WebhookSecret: "secret2",
+								},
+							},
+						},
+						GitLabAuths: []v1alpha1.GitLab{
+							{
+								GroupsProject: "group/subgroup:project",
+								Auth: v1alpha1.GitLabAuth{
+									Accesstoken: "token2",
+								},
+							},
+							{
+								GroupsProject: "group/subgroup",
+								Auth: v1alpha1.GitLabAuth{
+									Accesstoken: "token3",
+								},
+							},
+						},
+					},
+				},
+				Repository: v1alpha1.Repository{
+					Store: "postgres",
+				},
+				DockerRegistries: map[string]v1alpha1.DockerRegistryCredentials{},
+			},
+		},
 	}
 
 	scheme := scheme.New()


### PR DESCRIPTION
The previous format was not mergeable by Strategic Patch Merge
which is an issue if you use e.g. secrets to inject configuration into
the platform.